### PR TITLE
Add HATEOAS links for company reports.

### DIFF
--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -1,6 +1,8 @@
 (ns open-company.representations.company
   (:require [cheshire.core :as json]
-            [open-company.representations.common :as common]))
+            [open-company.representations.common :as common]
+            [open-company.representations.report :as report-rep]
+            [open-company.resources.report :as report]))
 
 (def media-type "application/vnd.open-company.company+json;version=1")
 
@@ -16,14 +18,21 @@
 (defn- delete-link [company]
   (common/delete-link (url company)))
 
-(defn company-links
+(defn- report-links [company]
+  (let [ticker (:symbol company)]
+    (map
+      #(common/link-map "report" common/GET (report-rep/url ticker (:year %) (:period %)) report-rep/media-type)
+      (report/list-reports ticker))))
+
+(defn- company-links
   "Add the HATEAOS links to the company"
   [company]
   (apply array-map (concat (flatten (vec company))
-    [:links [
+    [:links (flatten [
       (self-link company)
       (update-link company)
-      (delete-link company)]])))
+      (delete-link company)
+      (report-links company)])])))
 
 (defn- company-to-json-map [company]
   ;; Generate JSON from the sorted array map that results from:

--- a/src/open_company/representations/report.clj
+++ b/src/open_company/representations/report.clj
@@ -4,8 +4,9 @@
 
 (def media-type "application/vnd.open-company.report+json;version=1")
 
-(defn- url [report]
-  (str "/v1/companies/" (:symbol report) "/" (:year report) "/" (:period report)))
+(defn url
+  ([report] (url (:symbol report) (:year report) (:period report)))
+  ([ticker year period] (str "/v1/companies/" ticker "/" year "/" period)))
 
 (defn- self-link [report]
   (common/self-link (url report) media-type))
@@ -16,7 +17,7 @@
 (defn- delete-link [report]
   (common/delete-link (url report)))
 
-(defn report-links
+(defn- report-links
   "Add the HATEAOS links to the report"
   [report]
   (apply array-map (concat (flatten (vec report))


### PR DESCRIPTION
https://trello.com/c/n5oBmwg2

To test follow the cURL in the README to create OPEN and BUFFR. Create 2 reports for OPEN and none for BUFFR.

Do a cURL GET on OPEN. See 2 report links in the links? Good.

Do a cURL GET on BUFFR. See no report links in the links? Hot damn.

Merge.