### PR TITLE
Fix to PUT response

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Update a company with cURL:
 
 ```console
 curl -i -X PUT \
--d '{"name": "Transparency, LLC", "currency": "USD", "web": {"company": "https://opencompany.io/"}}' \
+-d '{"name": "Transparency, LLC", "currency": "USD", "web": {"about": "https://opencompany.io/about"}}' \
 --header "Accept: application/vnd.open-company.company+json;version=1" \
 --header "Accept-Charset: utf-8" \
 --header "Content-Type: application/vnd.open-company.company+json;version=1" \
@@ -278,7 +278,7 @@ Update the report with cURL:
 
 ```console
 curl -i -X PUT \
--d '{"headcount": {"founders": 2, "contractors": 2}}' \
+-d '{"headcount": {"founders": 3}}' \
 --header "Accept: application/vnd.open-company.report+json;version=1" \
 --header "Accept-Charset: utf-8" \
 --header "Content-Type: application/vnd.open-company.report+json;version=1" \

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -33,7 +33,7 @@
 (defn- put-company [ticker company]
   (let [full-company (assoc company :symbol ticker)
         company-result (company/put-company ticker full-company)]
-    {:company company-result}))
+    {:updated-company company-result}))
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
 
@@ -51,7 +51,7 @@
   ;; Handlers
   :handle-ok (by-method {
     :get (fn [ctx] (company-rep/render-company (:company ctx)))
-    :put (fn [ctx] (company-rep/render-company (:company ctx)))})
+    :put (fn [ctx] (company-rep/render-company (:updated-company ctx)))})
   :handle-not-acceptable (fn [_] (common/only-accept 406 company-rep/media-type))
   :handle-unsupported-media-type (fn [_] (common/only-accept 415 company-rep/media-type))
   :handle-unprocessable-entity (fn [ctx] (unprocessable-reason (:reason ctx)))
@@ -62,7 +62,7 @@
   ;; Create or update a company
   :new? (by-method {:put (not (company/get-company ticker))})
   :put! (fn [ctx] (put-company ticker (add-ticker ticker (:data ctx))))
-  :handle-created (fn [ctx] (company-location-response (:company ctx))))
+  :handle-created (fn [ctx] (company-location-response (:updated-company ctx))))
 
 (defresource company-list []
   :available-charsets [common/UTF8]

--- a/src/open_company/api/reports.clj
+++ b/src/open_company/api/reports.clj
@@ -25,7 +25,7 @@
     {:report report}))
 
 (defn- put-report [ticker year period report]
-  (let [full-report (merge report {:symbol ticker :year year :period period})
+  (let [full-report (merge report {:symbol ticker :year (Integer. year) :period period})
         report-result (report/put-report full-report)]
       {:report report-result}))
 

--- a/src/open_company/api/reports.clj
+++ b/src/open_company/api/reports.clj
@@ -27,7 +27,7 @@
 (defn- put-report [ticker year period report]
   (let [full-report (merge report {:symbol ticker :year (Integer. year) :period period})
         report-result (report/put-report full-report)]
-      {:report report-result}))
+      {:updated-report report-result}))
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
 
@@ -45,7 +45,7 @@
   ;; Handlers
   :handle-ok (by-method {
     :get (fn [ctx] (report-rep/render-report (:report ctx)))
-    :put (fn [ctx] (report-rep/render-report (:report ctx)))})
+    :put (fn [ctx] (report-rep/render-report (:updated-report ctx)))})
   :handle-not-acceptable (fn [_] (common/only-accept 406 report-rep/media-type))
   :handle-unsupported-media-type (fn [_] (common/only-accept 415 report-rep/media-type))
   :handle-unprocessable-entity (fn [ctx] (unprocessable-reason (:reason ctx)))
@@ -56,7 +56,7 @@
   ;; Create or update a report
   :new? (by-method {:put (not (report/get-report ticker year period))})
   :put! (fn [ctx] (put-report ticker year period (:data ctx)))
-  :handle-created (fn [ctx] (report-location-response (:report ctx))))
+  :handle-created (fn [ctx] (report-location-response (:updated-report ctx))))
 
 ;; ----- Routes -----
 

--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -1,5 +1,6 @@
 (ns open-company.representations.company
-  (:require [cheshire.core :as json]
+  (:require [defun :refer (defun)]
+            [cheshire.core :as json]
             [open-company.representations.common :as common]
             [open-company.representations.report :as report-rep]
             [open-company.resources.report :as report]))
@@ -7,8 +8,9 @@
 (def media-type "application/vnd.open-company.company+json;version=1")
 (def collection-media-type "application/vnd.collection+vnd.open-company.company+json;version=1")
 
-(defn- url [company]
-  (str "/v1/companies/" (:symbol company)))
+(defun url 
+  ([ticker :guard string?] (str "/v1/companies/" ticker))
+  ([company] (url (:symbol company))))
 
 (defn- self-link [company]
   (common/self-link (url company) media-type))

--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -10,7 +10,7 @@
 
 (defun url 
   ([ticker :guard string?] (str "/v1/companies/" ticker))
-  ([company] (url (:symbol company))))
+  ([company :guard map?] (url (:symbol company))))
 
 (defn- self-link [company]
   (common/self-link (url company) media-type))

--- a/src/open_company/resources/report.clj
+++ b/src/open_company/resources/report.clj
@@ -26,7 +26,7 @@
 (defun valid-year?
   "Return `true` if the specified period is valid, `false` if not."
   ([year :guard integer?] (and (> year 1900) (< year 3000)))
-  ([year :guard #(and (string? %) (not-a-number? %))] false)
+  ([_year :guard #(and (string? %) (not-a-number? %))] false)
   ([year :guard string?] (valid-year? (Integer. year))))
 
 (defn valid-period?

--- a/src/open_company/resources/report.clj
+++ b/src/open_company/resources/report.clj
@@ -17,10 +17,17 @@
 
 ;; ----- Validations -----
 
+(defn- not-a-number? 
+  "Return `true` if the string cannot be converted into an integer."
+  [string]
+  (try (Integer. string) false
+    (catch NumberFormatException e true)))
+
 (defun valid-year?
   "Return `true` if the specified period is valid, `false` if not."
   ([year :guard integer?] (and (> year 1900) (< year 3000)))
-  ([year :guard string?] (valid-year? (Integer. (re-find  #"\d+" year)))))
+  ([year :guard #(and (string? %) (not-a-number? %))] false)
+  ([year :guard string?] (valid-year? (Integer. year))))
 
 (defn valid-period?
   "Return `true` if the specified period is valid, `false` if not."

--- a/test/open_company/integration/company/company_create.clj
+++ b/test/open_company/integration/company/company_create.clj
@@ -2,6 +2,7 @@
   (:require [midje.sweet :refer :all]
             [open-company.lib.rest-api-mock :as mock]
             [open-company.lib.hateoas :as hateoas]
+            [open-company.lib.resources :as r]
             [open-company.resources.company :as company]
             [open-company.representations.company :as company-rep]
             [open-company.resources.report :as report]))
@@ -32,29 +33,8 @@
 ;; body not valid JSON
 ;; no name in body
 
-;; ----- Test Data -----
-
-(def TICKER "OPEN")
-(def OPEN {:symbol TICKER :name "Transparency, LLC" :url "https://opencompany.io/"})
-(def UNI {:symbol TICKER :name "$€¥£ &‼⁇ ∆∰≈ ☃♔☂Ǽ ḈĐĦ, LLC" :url "https://opencompany.io/"})
-
-;; ----- Utilities -----
-
-(defn- create-company-with-api
-  "Makes an API request to create the company and returns the response."
-  ([ticker body]
-     (mock/api-request :put (str "/v1/companies/" ticker) {
-      :headers {
-        :Accept-Charset "utf-8"
-        :Accept company-rep/media-type
-        :Content-Type company-rep/media-type}
-      :body body}))
-  ([headers ticker body]
-     (mock/api-request :put (str "/v1/companies/" ticker) {
-        :headers headers
-        :body body})))
-
 ;; ----- Tests -----
+
 (with-state-changes [(before :facts (company/delete-all-companies!))
                      (after :facts (company/delete-all-companies!))]
 
@@ -71,13 +51,13 @@
     )
     (fact "when the ticker symbol in the body and the URL match"
       ;; Create the company
-      (let [response (create-company-with-api TICKER OPEN)]
+      (let [response (mock/put-company-with-api r/TICKER r/OPEN)]
         (:status response) => 201
         (mock/response-mime-type response) => (mock/base-mime-type company-rep/media-type)
         (mock/response-location response) => "/v1/companies/OPEN"
         (mock/json? response) => true
-        (hateoas/verify-company-links TICKER (:links (mock/body-from-response response))))
+        (hateoas/verify-company-links r/TICKER (:links (mock/body-from-response response))))
       ;; Get the created company and make sure it's right
-      (company/get-company TICKER) => (contains OPEN)
+      (company/get-company r/TICKER) => (contains r/OPEN)
       ;; Reports are empty?
-      (report/report-count TICKER) => 0)))
+      (report/report-count r/TICKER) => 0)))

--- a/test/open_company/integration/company/company_create.clj
+++ b/test/open_company/integration/company/company_create.clj
@@ -40,21 +40,13 @@
 
   (facts "about using the REST API to create valid new companies"
 
-    (comment
-      all good - 201 Created
-      curl -i -X PUT \
-      -d "{symbol: 'OPEN', name: 'Transparency, LLC', url: 'https://opencompany.io/'}" \
-      --header "Accept: application/vnd.open-company.company+json;version=1" \
-      --header "Accept-Charset: utf-8" \
-      --header "Content-Type: application/vnd.open-company.company+json;version=1" \
-      http://localhost:3000/v1/companies/OPEN
-    )
+    ;; all good - 201 Created
     (fact "when the ticker symbol in the body and the URL match"
       ;; Create the company
       (let [response (mock/put-company-with-api r/TICKER r/OPEN)]
         (:status response) => 201
         (mock/response-mime-type response) => (mock/base-mime-type company-rep/media-type)
-        (mock/response-location response) => "/v1/companies/OPEN"
+        (mock/response-location response) => (company-rep/url r/TICKER)
         (mock/json? response) => true
         (hateoas/verify-company-links r/TICKER (:links (mock/body-from-response response))))
       ;; Get the created company and make sure it's right

--- a/test/open_company/integration/company/company_update.clj
+++ b/test/open_company/integration/company/company_update.clj
@@ -1,0 +1,86 @@
+(ns open-company.integration.company.company-update
+  (:require [midje.sweet :refer :all]
+            [open-company.lib.rest-api-mock :as mock]
+            [open-company.lib.hateoas :as hateoas]
+            [open-company.lib.resources :as r]
+            [open-company.resources.company :as company]
+            [open-company.representations.company :as company-rep]
+            [open-company.resources.report :as report]))
+
+;; ----- Test Cases -----
+
+;; Updating companies with the REST API
+
+;; The system should update valid companies and handle the following scenarios:
+
+;; PUT
+;; all good, updating a property - 200 OK
+;; all good, adding a property - 200 OK
+;; all good, removing a property - 200 OK
+;; all good, no ticker symbol in body - 200 OK
+;; all good, unicode in the body - 200 OK
+
+;; bad, ticker symbol has invalid characters
+;; bad, ticker symbol is too long
+;; bad, ticker symbol in body is different than the provided URL
+
+;; good, no accept - 200 OK
+;; good, no content type - 200 OK
+;; good, no charset - 200 OK
+
+;; bad, conflicting reserved properties
+;; bad, wrong accept
+;; bad, wrong content type
+;; bad, no body
+;; bad, wrong charset
+;; bad, body not valid JSON
+
+;; ----- Tests -----
+
+(with-state-changes [(before :facts (do (company/delete-all-companies!) (company/create-company r/OPEN)))
+                     (after :facts (company/delete-all-companies!))]
+
+  (facts "about using the REST API to update companies"
+
+    ;; all good - 201 Created
+    (fact "when updating a property"
+      ;; Update the company
+      (let [updated-company (assoc-in r/OPEN [:web :company] "https://opencompany.io")
+            response (mock/put-company-with-api r/TICKER updated-company)]
+        (:status response) => 200
+        (mock/response-mime-type response) => (mock/base-mime-type company-rep/media-type)
+        (mock/json? response) => true
+        (mock/body-from-response response) => (contains updated-company)
+        (hateoas/verify-company-links r/TICKER (:links (mock/body-from-response response)))
+        ;; Get the updated company and make sure it's right
+        (company/get-company r/TICKER) => (contains updated-company)))
+
+    ;; all good - 201 Created
+    (fact "when adding a property"
+      ;; Update the company
+      (let [updated-company (assoc-in r/OPEN [:web :about] "https://opencompany.io/about")
+            response (mock/put-company-with-api r/TICKER updated-company)]
+        (:status response) => 200
+        (mock/response-mime-type response) => (mock/base-mime-type company-rep/media-type)
+        (mock/json? response) => true
+        (mock/body-from-response response) => (contains updated-company)
+        (hateoas/verify-company-links r/TICKER (:links (mock/body-from-response response)))
+        ;; Get the updated company and make sure it's right
+        (company/get-company r/TICKER) => (contains updated-company)))
+
+    ;; all good - 201 Created
+    (fact "when removing a property"
+      ;; Update the company
+      (let [updated-company (update-in r/OPEN [:web] dissoc :company)
+            response (mock/put-company-with-api r/TICKER updated-company)
+            body (mock/body-from-response response)]
+        (:status response) => 200
+        (mock/response-mime-type response) => (mock/base-mime-type company-rep/media-type)
+        (mock/json? response) => true
+        body => (contains updated-company)
+        (get-in body [:web :company]) => nil
+        (hateoas/verify-company-links r/TICKER (:links (mock/body-from-response response)))
+        ;; Get the updated company and make sure it's right
+        (let [retrieved-company (company/get-company r/TICKER)]
+           retrieved-company => (contains updated-company)
+           (get-in retrieved-company [:web :company]) => nil)))))

--- a/test/open_company/integration/report/report_create.clj
+++ b/test/open_company/integration/report/report_create.clj
@@ -1,0 +1,60 @@
+(ns open-company.integration.report.report-create
+  (:require [midje.sweet :refer :all]
+            [open-company.lib.rest-api-mock :as mock]
+            [open-company.lib.hateoas :as hateoas]
+            [open-company.lib.resources :as r]
+            [open-company.resources.company :as company]
+            [open-company.resources.report :as report]
+            [open-company.representations.report :as report-rep]))
+
+;; ----- Test Cases -----
+
+;; Creating reports with the REST API
+
+;; The system should store newly created valid reports and handle the following scenarios:
+
+;; PUT
+;; all good - 201 Created
+;; all good, no ticker symbol in body - 201 Created
+;; all good, no year in the body - 201 Created
+;; all good, no period in the body - 201 Created
+;; all good, unicode in the body - 201 Created
+
+;; bad, year has invalid characters
+;; bad, year is outside of bounds
+;; bad, period is invalid
+;; bad, ticker symbol in body is different than the provided URL
+;; bad, year in body is different than the provided URL
+;; bad, priod in body is different than the provided URL
+
+;; good, no accept - 201 Created
+;; good, no content type - 201 Created
+;; good, no charset - 201 Created
+
+;; bad, conflicting reserved properties
+;; bad, wrong accept
+;; bad, wrong content type
+;; bad, no body
+;; bad, wrong charset
+;; bad, body not valid JSON
+
+;; ----- Tests -----
+
+(with-state-changes [(before :facts (do (company/delete-all-companies!)(company/create-company r/OPEN)))
+                     (after :facts (company/delete-all-companies!))]
+
+  (facts "about using the REST API to create valid new reports"
+
+    ; all good - 201 Created
+    (fact "when the ticker symbol in the body and the URL match"
+      ;; Create the report
+      (let [response (mock/put-report-with-api r/TICKER 2015 "Q2" r/OPEN-2015-Q2)]
+        (:status response) => 201
+        (mock/response-mime-type response) => (mock/base-mime-type report-rep/media-type)
+        (mock/response-location response) => "/v1/companies/OPEN/2015/Q2"
+        (mock/json? response) => true
+        (hateoas/verify-report-links r/TICKER 2015 "Q2" (:links (mock/body-from-response response))))
+      ;; Get the created report and make sure it's right
+      (report/get-report r/TICKER 2015 "Q2") => (contains r/OPEN-2015-Q2)
+      ;; There is 1 report?
+      (report/report-count r/TICKER) => 1)))

--- a/test/open_company/integration/report/report_update.clj
+++ b/test/open_company/integration/report/report_update.clj
@@ -1,0 +1,100 @@
+(ns open-company.integration.report.report-update
+  (:require [midje.sweet :refer :all]
+            [open-company.lib.rest-api-mock :as mock]
+            [open-company.lib.hateoas :as hateoas]
+            [open-company.lib.resources :as r]
+            [open-company.resources.company :as company]
+            [open-company.resources.report :as report]
+            [open-company.representations.report :as report-rep]))
+
+;; ----- Test Cases -----
+
+;; Updating reports with the REST API
+
+;; The system should update reports and handle the following scenarios:
+
+;; PUT
+;; all good, updating a property - 200 OK
+;; all good, adding a property - 200 OK
+;; all good, removing a property - 200 OK
+;; all good, no ticker symbol in body - 200 OK
+;; all good, no year in the body - 200 OK
+;; all good, no period in the body - 200 OK
+;; all good, unicode in the body - 200 OK
+
+;; bad, year has invalid characters
+;; bad, year is outside of bounds
+;; bad, period is invalid
+;; bad, ticker symbol in body is different than the provided URL
+;; bad, year in body is different than the provided URL
+;; bad, priod in body is different than the provided URL
+
+;; good, no accept - 200 OK
+;; good, no content type - 200 OK
+;; good, no charset - 200 OK
+
+;; bad, conflicting reserved properties
+;; bad, wrong accept
+;; bad, wrong content type
+;; bad, no body
+;; bad, wrong charset
+;; bad, body not valid JSON
+
+;; ----- Tests -----
+
+(with-state-changes [(before :facts (do 
+                                      (company/delete-all-companies!)
+                                      (company/create-company r/OPEN)
+                                      (report/create-report r/OPEN-2015-Q2)))
+                     (after :facts (company/delete-all-companies!))]
+
+  (facts "about using the REST API to update reports"
+
+    ; all good, updating a property - 200 OK
+    (fact "when updating a property"
+      ;; Create the report
+      (let [updated-report (assoc-in r/OPEN [:finances :revenue] 0)
+           response (mock/put-report-with-api r/TICKER 2015 "Q2" updated-report)]
+        (:status response) => 200
+        (mock/response-mime-type response) => (mock/base-mime-type report-rep/media-type)
+        (mock/json? response) => true
+        (mock/body-from-response response) => (contains updated-report)
+        (hateoas/verify-report-links r/TICKER 2015 "Q2" (:links (mock/body-from-response response)))
+        ;; Get the updated report and make sure it's right
+        (report/get-report r/TICKER 2015 "Q2") => (contains updated-report))
+      ;; There is still 1 report?
+      (report/report-count r/TICKER) => 1)
+
+    ; all good, adding a property - 200 OK
+    (fact "when adding a property"
+      ;; Create the report
+      (let [updated-report (assoc-in r/OPEN [:headcount :executives] 0)
+           response (mock/put-report-with-api r/TICKER 2015 "Q2" updated-report)]
+        (:status response) => 200
+        (mock/response-mime-type response) => (mock/base-mime-type report-rep/media-type)
+        (mock/json? response) => true
+        (mock/body-from-response response) => (contains updated-report)
+        (hateoas/verify-report-links r/TICKER 2015 "Q2" (:links (mock/body-from-response response)))
+        ;; Get the updated report and make sure it's right
+        (report/get-report r/TICKER 2015 "Q2") => (contains updated-report))
+      ;; There is still 1 report?
+      (report/report-count r/TICKER) => 1)
+
+    ; all good, updating a property - 200 OK
+    (fact "when removing a property"
+      ;; Create the report
+      (let [updated-report (dissoc r/OPEN :compensation)
+           response (mock/put-report-with-api r/TICKER 2015 "Q2" updated-report)
+           body (mock/body-from-response response)]
+        (:status response) => 200
+        (mock/response-mime-type response) => (mock/base-mime-type report-rep/media-type)
+        (mock/json? response) => true
+        body => (contains updated-report)
+        (:compensation body) => nil
+        (hateoas/verify-report-links r/TICKER 2015 "Q2" (:links (mock/body-from-response response)))
+        ;; Get the updated report and make sure it's right
+        (let [retrieved-report (report/get-report r/TICKER 2015 "Q2")]
+          retrieved-report => (contains updated-report)
+          (:compensation retrieved-report) => nil))
+      ;; There is still 1 report?
+      (report/report-count r/TICKER) => 1)))

--- a/test/open_company/lib/hateoas.clj
+++ b/test/open_company/lib/hateoas.clj
@@ -2,7 +2,8 @@
   "Utility functions for testing HATEOAS https://en.wikipedia.org/wiki/HATEOAS"
   (:require [open-company.lib.check :refer (check)]
             [open-company.representations.common :refer (GET POST PUT PATCH DELETE)]
-            [open-company.representations.company :as company-rep]))
+            [open-company.representations.company :as company-rep]
+            [open-company.representations.report :as report-rep]))
 
 (defn- find-link [rel links]
   (some (fn [link] (if (= rel (:rel link)) link nil)) links))
@@ -19,8 +20,16 @@
 
 (defn verify-company-links [ticker links]
   (check (= (count links) 3))
-  (let [url (str "/v1/companies/" ticker)]
+  (let [url (company-rep/url ticker)]
     (verify-link "self" GET url company-rep/media-type links)
     (verify-link "update" PUT url company-rep/media-type links)
     ;(verify-link "partial-update" PATCH url company-rep/media-type links)
+    (verify-link "delete" DELETE url :no links)))
+
+(defn verify-report-links [ticker year period links]
+  (check (= (count links) 3))
+  (let [url (report-rep/url ticker year period)]
+    (verify-link "self" GET url report-rep/media-type links)
+    (verify-link "update" PUT url report-rep/media-type links)
+    ;(verify-link "partial-update" PATCH url report-rep/media-type links)
     (verify-link "delete" DELETE url :no links)))

--- a/test/open_company/lib/resources.clj
+++ b/test/open_company/lib/resources.clj
@@ -3,11 +3,11 @@
 
 ;; ----- Names / constants -----
 
-(def ascii-name "test this")
-(def unicode-name "私はガラスを食")
-(def mixed-name (str "test " unicode-name))
-(def long-unicode-name " -tHiS #$is%?-----ελληνικήalso-მივჰხვდემასჩემსაãالزجاجوهذالايؤلمني-slüg♜-♛-☃-✄-✈  - ")
-(def names [ascii-name unicode-name mixed-name long-unicode-name])
+(def ascii "test this")
+(def unicode "私はガラスを食")
+(def mixed-ascii-unicode (str "test " unicode))
+(def long-unicode " -tHiS #$is%?-----ελληνικήalso-მივჰხვდემასჩემსაãالزجاجوهذالايؤلمني-slüg♜-♛-☃-✄-✈  - ")
+(def names [ascii unicode mixed-ascii-unicode long-unicode])
 
 (def TICKER "OPEN")
 (def too-long "1234546")
@@ -17,5 +17,42 @@
 
 ;; ----- Companies -----
 
-(def OPEN {:symbol TICKER :name "Transparency, LLC" :url "https://opencompany.io/"})
-(def UNI {:symbol TICKER :name "$€¥£ &‼⁇ ∆∰≈ ☃♔☂Ǽ ḈĐĦ, LLC" :url "https://opencompany.io/"})
+(def OPEN {
+  :symbol TICKER
+  :name "Transparency, LLC"
+  :currency "USD"
+  :web {:company "https://opencompany.io/"}})
+
+(def UNI {
+  :symbol TICKER
+  :name "$€¥£ &‼⁇ ∆∰≈ ☃♔☂Ǽ ḈĐĦ, LLC"
+  :currency "USD"
+  :web {:company "https://opencompany.io/"}})
+
+;; ----- Reports -----
+
+(def OPEN-2015-Q2 {
+  :symbol "OPEN"
+  :year 2015
+  :period "Q2"
+  :finances {
+    :cash 173228
+    :revenue 2767
+    :costs 22184
+    :comment "This is a comment."
+  }
+  :headcount {
+    :founders 2
+    :ft-employees 3
+    :pt-employees 0
+    :contractors 1
+    :comment "This is another comment."
+  }
+  :compensation {
+    :percentage false
+    :founders 6357
+    :employees 5899
+    :contractors 2582
+    :comment "More comments for you."
+  }
+})

--- a/test/open_company/lib/resources.clj
+++ b/test/open_company/lib/resources.clj
@@ -9,10 +9,13 @@
 (def long-unicode-name " -tHiS #$is%?-----ελληνικήalso-მივჰხვდემასჩემსაãالزجاجوهذالايؤلمني-slüg♜-♛-☃-✄-✈  - ")
 (def names [ascii-name unicode-name mixed-name long-unicode-name])
 
-(def ok "OPEN")
+(def TICKER "OPEN")
 (def too-long "1234546")
 
 (def bad-symbols [nil "" " " 42 42.7 {} [] #{}])
 (def bad-names bad-symbols)
 
-(def oc {:symbol ok :name "Transparency, LLC" :url "https://opencompany.io/"})
+;; ----- Companies -----
+
+(def OPEN {:symbol TICKER :name "Transparency, LLC" :url "https://opencompany.io/"})
+(def UNI {:symbol TICKER :name "$€¥£ &‼⁇ ∆∰≈ ☃♔☂Ǽ ḈĐĦ, LLC" :url "https://opencompany.io/"})

--- a/test/open_company/lib/rest_api_mock.clj
+++ b/test/open_company/lib/rest_api_mock.clj
@@ -1,9 +1,11 @@
 (ns open-company.lib.rest-api-mock
   "Utility functions to help with REST API mock testing."
   (:require [clojure.string :as s]
-            [open-company.app :refer (app)]
+            [defun :refer (defun)]
             [ring.mock.request :refer (request body content-type header)]
-            [cheshire.core :as json]))
+            [cheshire.core :as json]
+            [open-company.app :refer (app)]
+            [open-company.representations.company :as company-rep]))
 
 (defn base-mime-type [full-mime-type]
   (first (s/split full-mime-type #";")))
@@ -53,3 +55,24 @@
   "True if the body of the response contains anything."
   [resp-map]
   (not (s/blank? (:body resp-map))))
+
+(defun put-with-api
+  "Makes a mock API request to PUT the resource and returns the response."
+  ([url :guard string? media-type body]
+     (api-request :put url {
+      :headers {
+        :Accept-Charset "utf-8"
+        :Accept media-type
+        :Content-Type media-type}
+      :body body}))
+  ([headers url body]
+     (api-request :put url {
+        :headers headers
+        :body body})))
+
+(defn put-company-with-api
+  "Makes a mock API request to create the company and returns the response."
+  ([ticker body]
+    (put-with-api (str "/v1/companies/" ticker) company-rep/media-type body))
+  ([headers ticker body]
+    (put-with-api headers (str "/v1/companies/" ticker) body)))

--- a/test/open_company/lib/rest_api_mock.clj
+++ b/test/open_company/lib/rest_api_mock.clj
@@ -5,7 +5,8 @@
             [ring.mock.request :refer (request body content-type header)]
             [cheshire.core :as json]
             [open-company.app :refer (app)]
-            [open-company.representations.company :as company-rep]))
+            [open-company.representations.company :as company-rep]
+            [open-company.representations.report :as report-rep]))
 
 (defn base-mime-type [full-mime-type]
   (first (s/split full-mime-type #";")))
@@ -73,6 +74,13 @@
 (defn put-company-with-api
   "Makes a mock API request to create the company and returns the response."
   ([ticker body]
-    (put-with-api (str "/v1/companies/" ticker) company-rep/media-type body))
+    (put-with-api (company-rep/url ticker) company-rep/media-type body))
   ([headers ticker body]
-    (put-with-api headers (str "/v1/companies/" ticker) body)))
+    (put-with-api headers (company-rep/url ticker) body)))
+
+(defn put-report-with-api
+  "Makes a mock API request to create the company and returns the response."
+  ([ticker year period body]
+    (put-with-api (report-rep/url ticker year period) report-rep/media-type body))
+  ([headers ticker year period body]
+    (put-with-api headers (report-rep/url ticker year period) body)))

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -8,23 +8,23 @@
                      (after :facts (c/delete-all-companies!))]
 
   (fact "about validity checks of a valid new companies"
-    (c/valid-company r/ok r/oc) => true)
+    (c/valid-company r/TICKER r/OPEN) => true)
 
   (facts "about validity checks of invalid new companies"
 
     (facts "when no ticker symbol is provided"
       (doseq [ticker r/bad-symbols]
-        (c/valid-company ticker (assoc r/oc :symbol ticker)) => :invalid-symbol
-        (c/valid-company ticker r/oc) => :invalid-symbol
-        (c/valid-company r/ok (assoc r/oc :symbol ticker)) => :invalid-symbol))
+        (c/valid-company ticker (assoc r/OPEN :symbol ticker)) => :invalid-symbol
+        (c/valid-company ticker r/OPEN) => :invalid-symbol
+        (c/valid-company r/TICKER (assoc r/OPEN :symbol ticker)) => :invalid-symbol))
 
     (facts "when no name is provided"
-      (c/valid-company r/ok (dissoc r/oc :name)) => :invalid-name
+      (c/valid-company r/TICKER (dissoc r/OPEN :name)) => :invalid-name
       (doseq [bad-name r/bad-names]
-        (c/valid-company r/ok (assoc r/oc :name bad-name)) => :invalid-name))
+        (c/valid-company r/TICKER (assoc r/OPEN :name bad-name)) => :invalid-name))
 
     (fact "when a ticker symbol that's too long is provided"
-      (c/valid-company r/too-long (assoc r/oc :symbol r/too-long)) => :invalid-symbol)
+      (c/valid-company r/too-long (assoc r/OPEN :symbol r/too-long)) => :invalid-symbol)
 
     (future-fact "when a ticker symbol with special characters is provided")
 
@@ -46,21 +46,21 @@
 
   (facts "about company creation"
 
-    (c/create-company r/oc) => (contains r/oc)
-    (c/get-company r/ok) => (contains r/oc)
+    (c/create-company r/OPEN) => (contains r/OPEN)
+    (c/get-company r/TICKER) => (contains r/OPEN)
 
     (facts "and unicode names"
       (doseq [good-name r/names]
-        (let [new-oc (assoc r/oc :name good-name)]
+        (let [new-oc (assoc r/OPEN :name good-name)]
           (c/create-company new-oc) => (contains new-oc)
-          (c/get-company r/ok) => (contains new-oc)
-          (c/delete-company r/ok))))
+          (c/get-company r/TICKER) => (contains new-oc)
+          (c/delete-company r/TICKER))))
 
     (facts "and timestamps"
-      (let [company (c/create-company r/oc)
+      (let [company (c/create-company r/OPEN)
             created-at (:created-at company)
             updated-at (:updated-at company)
-            retrieved-company (c/get-company r/ok)]
+            retrieved-company (c/get-company r/TICKER)]
         (check/timestamp? created-at) => true
         (check/about-now? created-at) = true
         (= created-at updated-at) => true

--- a/test/open_company/unit/resources/company/company_update.clj
+++ b/test/open_company/unit/resources/company/company_update.clj
@@ -7,26 +7,26 @@
 
 (with-state-changes [(before :facts (do
                                       (c/delete-all-companies!)
-                                      (c/create-company r/oc)))
+                                      (c/create-company r/OPEN)))
                      (after :facts (c/delete-all-companies!))]
 
   (future-facts "about company update failures")
 
   (facts "about updating companies"
 
-    (let [new-oc (assoc r/oc :name "Transparency, Inc.")]
+    (let [new-oc (assoc r/OPEN :name "Transparency, Inc.")]
       (c/update-company new-oc) => (contains new-oc)
-      (c/get-company r/ok) => (contains new-oc))
+      (c/get-company r/TICKER) => (contains new-oc))
 
     (future-facts "when updating the ticker symbol")
 
     (facts "and timestamps"
       (Thread/sleep 1000) ; delay for 1 second to allow timestamps to differ
-      (let [new-oc (assoc r/oc :name "Transparency, Inc.")
+      (let [new-oc (assoc r/OPEN :name "Transparency, Inc.")
             company (c/update-company new-oc)
             created-at (:created-at company)
             updated-at (:updated-at company)
-            retrieved-company (c/get-company r/ok)]
+            retrieved-company (c/get-company r/TICKER)]
         (check/timestamp? created-at) => true
         (check/timestamp? updated-at) => true
         (= created-at updated-at) => false


### PR DESCRIPTION
https://trello.com/c/hJ9yLZEC

The responses from a PUT update of a company or a report would still have properties that were removed from the update. This adds failing integration tests for both company and report, and then fixes that so they pass. It also refactors and DRYs the tests some.

The key fixes are in `open-company.api.companies` and `open-company.api.reports`. Study those.

To test:

Note the new integration update tests for report and company. Study them and convince yourself they test the problem. Then run the tests!

```console
lein test!
```

They pass? Shazam!

Still not convinced. Checkout the updated cURL examples in the README. Run those against mainline, see the bug? Now switch back to this branch and run them again. See the fix? Holy boogers, that's good stuff. Merge it.