### PR TITLE
Update API versioning scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,10 +220,10 @@ Create a company with cURL:
 ```console
 curl -i -X PUT \
 -d '{"name": "Transparency, LLC", "currency": "USD", "web": {"company": "https://opencompany.io"}}' \
---header "Accept: application/vnd.open-company.company+json;version=1" \
+--header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
---header "Content-Type: application/vnd.open-company.company+json;version=1" \
-http://localhost:3000/v1/companies/OPEN
+--header "Content-Type: application/vnd.open-company.company.v1+json" \
+http://localhost:3000/companies/OPEN
 ```
 
 List the companies with cURL:
@@ -231,16 +231,16 @@ List the companies with cURL:
 ```console
 curl -i -X GET \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/v1/companies
+http://localhost:3000/companies
 ```
 
 Request the company with cURL:
 
 ```console
 curl -i -X GET \
---header "Accept: application/vnd.open-company.company+json;version=1" \
+--header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/v1/companies/OPEN
+http://localhost:3000/companies/OPEN
 ```
 
 Update a company with cURL:
@@ -248,10 +248,10 @@ Update a company with cURL:
 ```console
 curl -i -X PUT \
 -d '{"name": "Transparency, LLC", "currency": "USD", "web": {"about": "https://opencompany.io/about"}}' \
---header "Accept: application/vnd.open-company.company+json;version=1" \
+--header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
---header "Content-Type: application/vnd.open-company.company+json;version=1" \
-http://localhost:3000/v1/companies/OPEN
+--header "Content-Type: application/vnd.open-company.company.v1+json" \
+http://localhost:3000/companies/OPEN
 ```
 
 Create a report for the company with cURL:
@@ -259,19 +259,19 @@ Create a report for the company with cURL:
 ```console
 curl -i -X PUT \
 -d '{"headcount": {"founders": 2, "contractors": 1}}' \
---header "Accept: application/vnd.open-company.report+json;version=1" \
+--header "Accept: application/vnd.open-company.report.v1+json" \
 --header "Accept-Charset: utf-8" \
---header "Content-Type: application/vnd.open-company.report+json;version=1" \
-http://localhost:3000/v1/companies/OPEN/2015/Q2
+--header "Content-Type: application/vnd.open-company.report.v1+json" \
+http://localhost:3000/companies/OPEN/reports/2015/Q2
 ```
 
 Request the report with cURL:
 
 ```console
 curl -i -X GET \
---header "Accept: application/vnd.open-company.report+json;version=1" \
+--header "Accept: application/vnd.open-company.report.v1+json" \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/v1/companies/OPEN/2015/Q2
+http://localhost:3000/companies/OPEN/reports/2015/Q2
 ```
 
 Update the report with cURL:
@@ -279,36 +279,36 @@ Update the report with cURL:
 ```console
 curl -i -X PUT \
 -d '{"headcount": {"founders": 3}}' \
---header "Accept: application/vnd.open-company.report+json;version=1" \
+--header "Accept: application/vnd.open-company.report.v1+json" \
 --header "Accept-Charset: utf-8" \
---header "Content-Type: application/vnd.open-company.report+json;version=1" \
-http://localhost:3000/v1/companies/OPEN/2015/Q2
+--header "Content-Type: application/vnd.open-company.report.v1+json" \
+http://localhost:3000/companies/OPEN/reports/2015/Q2
 ```
 
 Delete the report with cURL:
 
 ```console
-curl -i -X DELETE http://localhost:3000/v1/companies/OPEN/2015/Q2
+curl -i -X DELETE http://localhost:3000/companies/OPEN/reports/2015/Q2
 ```
 
 Delete the company with cURL:
 
 ```console
-curl -i -X DELETE http://localhost:3000/v1/companies/OPEN
+curl -i -X DELETE http://localhost:3000/companies/OPEN
 ```
 
 Try (and fail) to get the report and the company with cURL:
 
 ```console
 curl -i -X GET \
---header "Accept: application/vnd.open-company.report+json;version=1" \
+--header "Accept: application/vnd.open-company.report.v1+json" \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/v1/companies/OPEN/2015/Q2
+http://localhost:3000/companies/OPEN/reports/2015/Q2
 
 curl -i -X GET \
---header "Accept: application/vnd.open-company.company+json;version=1" \
+--header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/v1/companies/OPEN
+http://localhost:3000/companies/OPEN
 ```
 
 

--- a/REPL_notes.clj
+++ b/REPL_notes.clj
@@ -42,7 +42,7 @@
 (company/delete-company "BUFFR")
 
 ;; make a (fake) REST API request
-(api-request :get "/v1/companies/OPEN" {:headers {:Accept (company-rep/media-type)}})
+(api-request :get "/companies/OPEN" {:headers {:Accept (company-rep/media-type)}})
 
 ;; print last exception
 (print-stack-trace *e)

--- a/api.yml
+++ b/api.yml
@@ -219,7 +219,7 @@ paths:
           
   # Paths for Reports
 
-  /companies/{symbol}/{year}/{period}:
+  /companies/{symbol}/reports/{year}/{period}:
     parameters:
       - $ref: '#/parameters/symbol'
       - $ref: '#/parameters/year'

--- a/api.yml
+++ b/api.yml
@@ -15,15 +15,15 @@ info:
   
 # Host, Base Path, Schemes and Content Types 
 host: api.opencompany.io
-basePath: /v1
+basePath: /
 schemes:
   - https
 produces:
-  - application/vnd.open-company.company+json;version=1
-  - application/vnd.open-company.report+json;version=1
+  - application/vnd.open-company.company.v1+json
+  - application/vnd.open-company.report.v1+json
 consumes:
-  - application/vnd.open-company.company+json;version=1
-  - application/vnd.open-company.report+json;version=1
+  - application/vnd.open-company.company.v1+json
+  - application/vnd.open-company.report.v1+json
 
 #
 # Security

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -14,7 +14,7 @@
 ;; ----- Responses -----
 
 (defn- company-location-response [company]
-  (common/location-response ["v1" "companies" (:symbol company)]
+  (common/location-response ["companies" (:symbol company)]
     (company-rep/render-company company) company-rep/media-type))
 
 (defn- unprocessable-reason [reason]
@@ -77,6 +77,6 @@
 ;; ----- Routes -----
 
 (defroutes company-routes
-  (ANY "/v1/companies/:ticker" [ticker] (company ticker))
-  (GET "/v1/companies/" [] (company-list))
-  (GET "/v1/companies" [] (company-list)))
+  (ANY "/companies/:ticker" [ticker] (company ticker))
+  (GET "/companies/" [] (company-list))
+  (GET "/companies" [] (company-list)))

--- a/src/open_company/api/reports.clj
+++ b/src/open_company/api/reports.clj
@@ -8,7 +8,7 @@
 ;; ----- Responses -----
 
 (defn- report-location-response [report]
-  (common/location-response ["v1" "companies" (:symbol report) (:year report) (:period report)]
+  (common/location-response ["companies" (:symbol report) "reports" (:year report) (:period report)]
     (report-rep/render-report report) report-rep/media-type))
 
 (defn- unprocessable-reason [reason]
@@ -61,4 +61,4 @@
 ;; ----- Routes -----
 
 (defroutes report-routes
-  (ANY "/v1/companies/:ticker/:year/:period" [ticker year period] (report ticker year period)))
+  (ANY "/companies/:ticker/reports/:year/:period" [ticker year period] (report ticker year period)))

--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -5,11 +5,11 @@
             [open-company.representations.report :as report-rep]
             [open-company.resources.report :as report]))
 
-(def media-type "application/vnd.open-company.company+json;version=1")
+(def media-type "application/vnd.open-company.company.v1+json")
 (def collection-media-type "application/vnd.collection+vnd.open-company.company+json;version=1")
 
 (defun url 
-  ([ticker :guard string?] (str "/v1/companies/" ticker))
+  ([ticker :guard string?] (str "/companies/" ticker))
   ([company :guard map?] (url (:symbol company))))
 
 (defn- self-link [company]
@@ -63,7 +63,7 @@
   (json/generate-string {
     :collection (array-map
       :version common/json-collection-version
-      :href "/v1/companies"
-      :links [(common/self-link (str "/v1/companies") collection-media-type)]
+      :href "/companies"
+      :links [(common/self-link (str "/companies") collection-media-type)]
       :companies (map company-link companies))}
     {:pretty true}))

--- a/src/open_company/representations/report.clj
+++ b/src/open_company/representations/report.clj
@@ -2,11 +2,11 @@
   (:require [cheshire.core :as json]
             [open-company.representations.common :as common]))
 
-(def media-type "application/vnd.open-company.report+json;version=1")
+(def media-type "application/vnd.open-company.report.v1+json")
 
 (defn url
   ([report] (url (:symbol report) (:year report) (:period report)))
-  ([ticker year period] (str "/v1/companies/" ticker "/" year "/" period)))
+  ([ticker year period] (str "/companies/" ticker "/reports/" year "/" period)))
 
 (defn- self-link [report]
   (common/self-link (url report) media-type))

--- a/test/open_company/integration/report/report_create.clj
+++ b/test/open_company/integration/report/report_create.clj
@@ -51,7 +51,7 @@
       (let [response (mock/put-report-with-api r/TICKER 2015 "Q2" r/OPEN-2015-Q2)]
         (:status response) => 201
         (mock/response-mime-type response) => (mock/base-mime-type report-rep/media-type)
-        (mock/response-location response) => "/v1/companies/OPEN/2015/Q2"
+        (mock/response-location response) => (report-rep/url r/TICKER 2015 "Q2")
         (mock/json? response) => true
         (hateoas/verify-report-links r/TICKER 2015 "Q2" (:links (mock/body-from-response response))))
       ;; Get the created report and make sure it's right


### PR DESCRIPTION
Read all about the various opinions and stances on REST api versioning. Though long and hard about it in my hammock.

Dropped the `/v1/` from the URLs. We'll use versioned subdomains instead. Also updated the versioning on the media-types to be `.v1` rather than `;version=1`. Liberator doesn't handle the  `;version=1` style as it assumes that's a different media-type since multiple media-types are separated by `;` (reasonable assumption really).

Lastly, updated the Reports API to use a `/reports/` in the URL to keep the namespace clean for potential future additions that are quarterly/monthly/yearly.

This updates the API and usage docs (README). 

To test: Read through the usage changes in the README. Changes all make sense? Execute the cURL command sequence in the README, all work? We have a winner!

To not break the UI, review this PR at the same time as: https://github.com/open-company/open-company-web/pull/17