### PR TITLE
Delete bug

### DIFF
--- a/REPL_notes.clj
+++ b/REPL_notes.clj
@@ -1,6 +1,7 @@
 ;; productive set of development namespaces (Clojure API)
 (require '[rethinkdb.query :as r])
 (require '[open-company.config :as c])
+(require '[open-company.db.init :as db])
 (require '[open-company.resources.common :as common] :reload)
 (require '[open-company.resources.company :as company] :reload)
 (require '[open-company.resources.report :as report] :reload)
@@ -11,6 +12,9 @@
 (require '[ring.mock.request :refer (request body content-type header)])
 (require '[open-company.lib.rest-api-mock :refer (api-request)] :reload)
 (require '[open-company.app :refer (app)] :reload)
+
+;; Init a DB
+(db/init)
 
 ;; Create a company
 (company/create-company {:symbol "OPEN" :name "Transparency, LLC" :currency "USD" :web {:company "https://opencompany.io"}})
@@ -33,6 +37,9 @@
 
 ;; Get a report
 (report/get-report "OPEN" 2015 "Q2")
+
+;; List reports
+(report/list-reports "OPEN")
 
 ;; Delete a report
 (report/delete-report "OPEN" 2015 "Q2")

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -64,16 +64,25 @@
       (throw (RuntimeException. (str "RethinkDB update failure: " update))))))
 
 (defn delete-resource
-  "Given a table name and a primary key value, delete the resource and return `true`."
-  [table-name primary-key]
-  (let [delete (with-open [conn (apply r/connect c/db-options)]
-                (-> (r/table table-name)
-                (r/get primary-key)
-                (r/delete)
-                (r/run conn)))]
-    (if (= 1 (:deleted delete))
-      true
-      (throw (RuntimeException. (str "RethinkDB delete failure: " delete))))))
+  "Delete the specified resource and return `true`."
+  ([table-name key-name key-value]
+    (let [delete (with-open [conn (apply r/connect c/db-options)]
+                  (-> (r/table table-name)
+                  (r/get-all [key-value] {:index key-name})
+                  (r/delete)
+                  (r/run conn)))]
+      (if (= 0 (:errors delete))
+        true
+        (throw (RuntimeException. (str "RethinkDB delete failure: " delete))))))
+  ([table-name primary-key-value]
+    (let [delete (with-open [conn (apply r/connect c/db-options)]
+                  (-> (r/table table-name)
+                  (r/get primary-key-value)
+                  (r/delete)
+                  (r/run conn)))]
+      (if (= 1 (:deleted delete))
+        true
+        (throw (RuntimeException. (str "RethinkDB delete failure: " delete)))))))
 
 ;; ----- Operations on collections of resources -----
 

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -64,6 +64,7 @@
 (defn delete-company
   "Given the ticker symbol of the company, delete it and all its reports and return `true` on success."
   [ticker]
+  (common/delete-resource :reports :symbol ticker)
   (common/delete-resource table-name ticker))
 
 ;; ----- Collection of companies -----

--- a/src/open_company/resources/report.clj
+++ b/src/open_company/resources/report.clj
@@ -1,5 +1,6 @@
 (ns open-company.resources.report
-  (:require [defun :refer (defun)]
+  (:require [clojure.string :as s]
+            [defun :refer (defun)]
             [rethinkdb.query :as r]
             [open-company.config :as c]
             [open-company.resources.common :as common]
@@ -53,10 +54,11 @@
 (defn get-report
   "Given the ticker symbol of the company and the year and period of the report,
   or the primary key, retrieve it from the database, or return nil if it doesn't exist."
-  ([ticker year period] (get-report ticker (key-for ticker year period)))
+  ([report-key] (get-report (first (s/split report-key #"-")) report-key))
   ([ticker report-key]
     (when (company/get-company ticker)
-      (common/read-resource table-name report-key))))
+      (common/read-resource table-name report-key)))
+  ([ticker year period] (get-report ticker (key-for ticker year period))))
 
 (defun create-report
   "Given the report property map, create the report returning the property map for the resource or `false`.

--- a/src/open_company/resources/report.clj
+++ b/src/open_company/resources/report.clj
@@ -53,9 +53,10 @@
 (defn get-report
   "Given the ticker symbol of the company and the year and period of the report,
   or the primary key, retrieve it from the database, or return nil if it doesn't exist."
-  ([ticker year period] (get-report (key-for ticker year period)))
-  ([report-key]
-    (common/read-resource table-name report-key)))
+  ([ticker year period] (get-report ticker (key-for ticker year period)))
+  ([ticker report-key]
+    (when (company/get-company ticker)
+      (common/read-resource table-name report-key))))
 
 (defun create-report
   "Given the report property map, create the report returning the property map for the resource or `false`.

--- a/src/open_company/resources/report.clj
+++ b/src/open_company/resources/report.clj
@@ -88,7 +88,7 @@
   [ticker]
   (vec (with-open [conn (apply r/connect c/db-options)]
     (-> (r/table table-name)
-      (r/get-all [ticker] {:index "symbol"})
+      (r/get-all [ticker] {:index :symbol})
       (r/with-fields ["year" "period"])
       (r/run conn)))))
 
@@ -97,7 +97,7 @@
   [ticker]
   (with-open [conn (apply r/connect c/db-options)]
     (-> (r/table table-name)
-      (r/get-all [ticker] {:index "symbol"})
+      (r/get-all [ticker] {:index :symbol})
       (r/count)
       (r/run conn))))
 


### PR DESCRIPTION
https://trello.com/c/sSYwUR0r

There are 2 (related) problems.

The 1st is that if you delete a company, its reports don't get deleted.

The 2nd is that if you DO have a report in the DB with no company, you can still retrieve it.

Both of these are now fixed.

To test:

On branch mainline:

Create a company and 2 reports (with the REPL and/or cURL).

Next, delete the company with cURL (command in the README).

Now retrieve one of the reports with cURL (command in the README). Notice you can STILL retrieve the report. Open RethinkDB data explorer and run: 

```javascript
r.db('open_company_dev').table('reports')
```

Notice the reports are still in the DB. This is no good.

Create the company again (with the REPL or cURL).

Switch to this new branch.

Delete the company again with cURL (command in the README).

Now retrieve one of the reports with cURL (command in the README). Notice you can't retrieve the report anymore. Better! Open RethinkDB data explorer and run: 

```javascript
r.db('open_company_dev').table('reports')
```

Notice the reports are gone. Yay!

Now for the 2nd problem, if you happen to end up with an orphan report somehow.

Switch back to mainline branch!

Create a company and a report (with the REPL and/or cURL).

Next, delete the company with cURL (command in the README). This will leave the report in the DB cause you did it w/o this fix.

Now retrieve the report with cURL. Notice you can retrieve it. This is bad.

Switch to this branch. Rerun your cURL command to retrieve the report. Notice you get a `404`.

Smashing man! Just smashing. Merge this branch and go kiss your Mom.