### PR TITLE
DRY up the section definitions to all be based on the sections.json asset

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,6 +17,7 @@
     [org.clojure/core.match "0.3.0-alpha4"] ; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.async "0.2.374"] ; Dependency of core.match and RethinkDB https://github.com/clojure/core.async
     [defun "0.3.0-alapha"] ; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
+    [lockedon/if-let "0.1.0"] ; More than one binding for if/when macros https://github.com/LockedOn/if-let
     [ring/ring-devel "1.4.0"] ; Web application library https://github.com/ring-clojure/ring
     [ring/ring-core "1.4.0"] ; Web application library https://github.com/ring-clojure/ring
     [jumblerg/ring.middleware.cors "1.0.1"] ; CORS library https://github.com/jumblerg/ring.middleware.cors

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -2,6 +2,7 @@
   (:require [defun :refer (defun)]
             [compojure.core :refer (defroutes ANY GET)]
             [liberator.core :refer (defresource by-method)]
+            [open-company.config :as config]
             [open-company.api.common :as common]
             [open-company.resources.common :as common-res]
             [open-company.resources.company :as company]
@@ -10,10 +11,7 @@
             [cheshire.core :as json]))
 
 ;; Round-trip it through Cheshire to ensure the embedded HTML gets encodedod or the client has issues parsing it
-(defonce sections (json/generate-string
-                    (json/decode
-                      (slurp (clojure.java.io/resource "open_company/assets/sections.json")))
-                      {:pretty true :escape-non-ascii true}))
+(defonce sections (json/generate-string config/sections {:pretty true}))
 
 (defun add-slug
   "Add the slug to the company properties if it's missing."

--- a/src/open_company/config.clj
+++ b/src/open_company/config.clj
@@ -1,6 +1,7 @@
 (ns open-company.config
   "Namespace for the configuration parameters."
   (:require [environ.core :refer (env)]
+            [cheshire.core :as json]
             [taoensso.timbre :as timbre]
             [taoensso.timbre.appenders.core :as appenders]))
 
@@ -35,6 +36,8 @@
 ;; ----- OpenCompany -----
 
 (defonce collapse-edit-time (or (env :open-company-collapse-edit-time) (* 24 60))) ; in minutes
+
+(defonce sections (json/decode (slurp (clojure.java.io/resource "open_company/assets/sections.json"))))
 
 ;; ----- Logging (see https://github.com/ptaoussanis/timbre) -----
 

--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -80,7 +80,7 @@
 (defn render-company
   "Create a JSON representation of a company for the REST API"
   [company]
-  (json/generate-string (company-for-rendering company) {:pretty true :escape-non-ascii true}))
+  (json/generate-string (company-for-rendering company) {:pretty true}))
 
 (defn render-company-list
   "Create a JSON representation of a group of companies for the REST API"
@@ -91,4 +91,4 @@
       :href "/companies"
       :links [(common/self-link (str "/companies") collection-media-type)]
       :companies (map company-link companies))}
-    {:pretty true :escape-non-ascii true}))
+    {:pretty true}))

--- a/src/open_company/representations/section.clj
+++ b/src/open_company/representations/section.clj
@@ -61,4 +61,4 @@
 (defn render-section
   "Create a JSON representation of the section for the REST API"
   [section]
-  (json/generate-string (section-for-rendering section) {:pretty true :escape-non-ascii true}))
+  (json/generate-string (section-for-rendering section) {:pretty true}))

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -29,7 +29,7 @@
             category (some #(if (= category-name (keyword (:name %))) %) categories)]
     (vec (map #(keyword (:name %)) (:sections category))))))
 
-;; Categories in default order as keys in a map with the value a vector of sections in each category in order
+;; Categories as keys in a map with the value a vector of sections in each category in order
 (def ordered-sections (zipmap categories (map sections-for categories)))
 
 (defun category-for


### PR DESCRIPTION
https://trello.com/c/tm1niuVx

We had a bug last week because the section name in the API internals didn't match the section name of the `sections.json` asset file (fundraising / fund-raising).

DRY'd that up so it won't be possible to have this kind of error. The `sections.json` file now provides the master list of all categories and sections.

To test:

0. Run `lein test!`
1. Run the REPL and try the Clojure code below
2. Look at the code changes
3. Do a few basic actions with the UI
4. Merge
5. Eat some ghost peppers

```clojure
(require '[open-company.resources.common :as common] :reload)
common/categories
(common/sections-for :progress)
(common/category-for :challenges)
common/ordered-sections
common/sections
```
