### PR TITLE
Fix some issues with the DB pool

### DIFF
--- a/src/open_company/config.clj
+++ b/src/open_company/config.clj
@@ -10,7 +10,7 @@
 (defonce db-host (or (env :db-host) "localhost"))
 (defonce db-port (or (env :db-port) 28015))
 (defonce db-name (or (env :db-name) "open_company"))
-(defonce db-pool-size (or (env :db-pool-size) 30))
+(defonce db-pool-size (or (env :db-pool-size) 60))
 
 (defonce db-map {:host db-host :port db-port :db db-name})
 (defonce db-options (flatten (vec db-map))) ; k/v sequence as clj-rethinkdb wants it


### PR DESCRIPTION
https://trello.com/c/4lF8ifK2

This PR improves the RethinkDB connection pool.

Specifically it throws an exception now if the pool is empty and no connection is available so we'll see this in Sentry. It also fixes a potential problem in the with-connection macro that may have prevented it from recovering properly from a pool empty scenario (it use to try to release nil from the pool).

To test:

0. Review the code
1. Review the new tests, do they test what they claim to? Run them with `lein test!`
2. Decrease the pool size to 2 in `config.clj` and change the log level to `:trace` in `config.clj`
3. Restart your API server, confirm the pool size is 2 in the output
4. Load Buffer in the web app
5. Notice that Buffer loads, but some of the pre-loading of prior sections fail w/ a 500
6. Look at your API server, notice you have RuntimeExceptions, in prod these would go to Sentry
7. Look at your `tmp/oc-api.log` file. Do you see the DB connections all getting used up and then the error message? `ERROR [open-company.db.pool] - No connection available from DB pool`
8. Reload Buffer in your browser. You should see the same behavior. Buffer loads but some of the pre-loads don't. This let's you know it recovers from a connection pool empty state and still works (cause your Buffer load worked).
9. Revert your `config.clj` changes and restart your API server
10. Merge
11. Deploy
12. Dance
