### PR TITLE
refactor token handling + allow-anon

### DIFF
--- a/src/open_company/api/common.clj
+++ b/src/open_company/api/common.clj
@@ -103,7 +103,7 @@
 
    If a valid token is supplied return a map containing :jwtoken and associated :user.
    If invalid token is supplied return {:jwtoken false}.
-   If not Authorization headers are supplied return nil."
+   If no Authorization headers are supplied return nil."
   [headers]
   (if-let [authorization (or (get headers "Authorization") (get headers "authorization"))]
     (let [jwtoken (last (s/split authorization #" "))]
@@ -113,12 +113,12 @@
         {:jwtoken false}))))
 
 (defn allow-anonymous
-  "Allow unless there is a JWToken provided and it's invalid"
+  "Allow unless there is a JWToken provided and it's invalid."
   [ctx]
   (boolean (or (nil? (:jwtoken ctx)) (:jwtoken ctx))))
 
 (defn allow-org-members
-  "Allow only if the user's JWToken indicates membership in the company's org"
+  "Allow only if there is no company, or the user's JWToken indicates membership in the company's org."
   [company-slug ctx]
   (let [user    (:user ctx)
         company (company/get-company company-slug)]

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -70,8 +70,8 @@
   :known-content-type? (fn [ctx] (common/known-content-type? ctx company-rep/media-type))
 
   :allowed? (by-method {
-    :options (fn [ctx] (common/allow-anonymous slug ctx))
-    :get (fn [ctx] (common/allow-anonymous slug ctx))
+    :options (fn [ctx] (common/allow-anonymous ctx))
+    :get (fn [ctx] (common/allow-anonymous ctx))
     :put (fn [ctx] (common/allow-org-members slug ctx))
     :patch (fn [ctx] (common/allow-org-members slug ctx))
     :delete (fn [ctx] (common/allow-org-members slug ctx))})

--- a/src/open_company/api/entry.clj
+++ b/src/open_company/api/entry.clj
@@ -29,11 +29,7 @@
   common/anonymous-resource
 
   :allowed-methods [:options :get]
-  ;; slug supplied to allow-anonymous here is irrelevant.
-  ;; the allowed? checking and token decoding should be
-  ;; decoupled and probably use :initialize-context for
-  ;; token decoding
-  :allowed? (fn [ctx] (common/allow-anonymous "foo" ctx))
+  :allowed? (fn [ctx] (common/allow-anonymous ctx))
   :available-media-types ["application/json"]
 
   :handle-not-acceptable (fn [_] (common/only-accept 406 "application/json"))

--- a/src/open_company/api/sections.clj
+++ b/src/open_company/api/sections.clj
@@ -49,8 +49,8 @@
   :known-content-type? (fn [ctx] (common/known-content-type? ctx section-rep/media-type))
 
   :allowed? (by-method {
-    :options (fn [ctx] (common/allow-anonymous company-slug ctx))
-    :get (fn [ctx] (common/allow-anonymous company-slug ctx))
+    :options (fn [ctx] (common/allow-anonymous ctx))
+    :get (fn [ctx] (common/allow-anonymous ctx))
     :put (fn [ctx] (common/allow-org-members company-slug ctx))
     :patch (fn [ctx] (common/allow-org-members company-slug ctx))})
 


### PR DESCRIPTION
This PR makes use of Liberators `:initialize-context` step for reading and decoding the `jwtoken` if present. If an invalid token is supplied `{:jwtoken false}` is merged into `ctx`.

By separating parsing/decoding of `jwtoken` from actual authentication the  `allow-anonymous` and `allow-org-members` checks became trivial removing the need for separate `authenticated?` and `authorized?` functions.

I tested this mostly by just running the test suite, I think since they cover the basic token situations at least once that should probably be enough. Also did a bit of `curl` testing and it's all working well.
