### PR TITLE
Connection Pooling w/ invalidation & with-timeout macro

### DIFF
--- a/src/open_company/app.clj
+++ b/src/open_company/app.clj
@@ -4,6 +4,7 @@
   (:require
     [liberator.dev :refer (wrap-trace)]
     [raven-clj.ring :refer (wrap-sentry)]
+    [taoensso.timbre :as timbre]
     [ring.middleware.params :refer (wrap-params)]
     [ring.middleware.reload :refer (wrap-reload)]
     [ring.middleware.cors :refer (wrap-cors)]
@@ -46,6 +47,7 @@
     hot-reload-routes))
 
 (defn start [port]
+  (timbre/set-config! config/log-config)
   (run-server app {:port port :join? false})
   (println (str "\n" (slurp (clojure.java.io/resource "open_company/assets/ascii_art.txt")) "\n"
     "OpenCompany API Server\n"

--- a/src/open_company/app.clj
+++ b/src/open_company/app.clj
@@ -47,7 +47,7 @@
     hot-reload-routes))
 
 (defn start [port]
-  (timbre/set-config! config/log-config)
+  (timbre/set-config! c/log-config)
   (run-server app {:port port :join? false})
   (println (str "\n" (slurp (clojure.java.io/resource "open_company/assets/ascii_art.txt")) "\n"
     "OpenCompany API Server\n"

--- a/src/open_company/app.clj
+++ b/src/open_company/app.clj
@@ -48,6 +48,11 @@
 
 (defn start [port]
   (timbre/set-config! c/log-config)
+  ;; See https://stuartsierra.com/2015/05/27/clojure-uncaught-exceptions
+  (Thread/setDefaultUncaughtExceptionHandler
+   (reify Thread$UncaughtExceptionHandler
+     (uncaughtException [_ thread ex]
+       (timbre/error ex "Uncaught exception on" (.getName thread)))))
   (run-server app {:port port :join? false})
   (println (str "\n" (slurp (clojure.java.io/resource "open_company/assets/ascii_art.txt")) "\n"
     "OpenCompany API Server\n"

--- a/src/open_company/app.clj
+++ b/src/open_company/app.clj
@@ -3,7 +3,9 @@
   (:gen-class)
   (:require
     [liberator.dev :refer (wrap-trace)]
-    [raven-clj.ring :refer (wrap-sentry)]
+    [raven-clj.core :as sentry]
+    [raven-clj.interfaces :as sentry-interfaces]
+    [raven-clj.ring :as sentry-mw]
     [taoensso.timbre :as timbre]
     [ring.middleware.params :refer (wrap-params)]
     [ring.middleware.reload :refer (wrap-reload)]
@@ -43,7 +45,7 @@
 (defonce app
   ;; Use sentry middleware to report runtime errors if we have a raven DSN.
   (if c/dsn
-    (wrap-sentry hot-reload-routes c/dsn)
+    (sentry-mw/wrap-sentry hot-reload-routes c/dsn)
     hot-reload-routes))
 
 (defn start [port]
@@ -52,8 +54,13 @@
   (Thread/setDefaultUncaughtExceptionHandler
    (reify Thread$UncaughtExceptionHandler
      (uncaughtException [_ thread ex]
-       (timbre/error ex "Uncaught exception on" (.getName thread)))))
+       (timbre/error ex "Uncaught exception on" (.getName thread))
+       (sentry/capture c/dsn (-> {:message (.getMessage ex)}
+                                 (assoc-in [:extra :exception-data] (ex-data ex))
+                                 (sentry-interfaces/stacktrace ex))))))
+
   (run-server app {:port port :join? false})
+
   (println (str "\n" (slurp (clojure.java.io/resource "open_company/assets/ascii_art.txt")) "\n"
     "OpenCompany API Server\n"
     "Running on port: " port "\n"

--- a/src/open_company/db/pool.clj
+++ b/src/open_company/db/pool.clj
@@ -1,113 +1,148 @@
 (ns open-company.db.pool
-  "RethinkDB database connection pool.
-
-  Simple pool that doesn't account for testing connection for validity
-  or connection reconnection.
-
-  Inspired by: https://github.com/robertluo/clj-poolman"
+  "RethinkDB database connection pool."
   (:require [rethinkdb.query :as r]
-            [taoensso.timbre :as timbre :refer (trace debug info warn error fatal)]
-            [open-company.config :as config]))
+            [taoensso.timbre :as timbre]
+            [open-company.config :as config])
+  (:import [java.util.concurrent LinkedBlockingQueue TimeUnit]))
 
-(timbre/set-config! config/log-config)
+;; Opening & closing of connections
 
-(def rethinkdb-pool (atom nil))
-
-;; ----- Grow the Pool with a New Connection -----
-
-(defn init-connection
-  []
+(defn init-connection []
   (apply r/connect config/db-options))
 
-(defn- next-id
-  "Find the next connection id (sequential numbers)"
-  [connections]
-  (let [ids (set (map :id connections))]
-    (first (remove ids (iterate inc 0)))))
+(defn close-conn [conn]
+  ;; Sometimes this blocks for reasons I don't yet understand
+  (timbre/trace "Closing connection...")
+  (rethinkdb.core/close conn)
+  (timbre/trace "Connection closed."))
 
-(defn- new-connection
-  "Make a new connection for the pool"
-  [init connections]
-  (let [id (next-id connections)]
-    {:id id :connection (init)}))
+;; Taken from the wonderful aphyr's Riemann
+;; https://github.com/riemann/riemann/blob/master/src/riemann/pool.clj
 
-(defn- assoc-new-connection
-  [{:keys [connections init] :as pool}]
-  (assoc pool :connections (conj connections (new-connection init connections))))
+(defprotocol Pool
+  (grow [pool]
+    "Adds an element to the pool.")
+  (claim [pool] [pool timeout]
+    "Take a thingy from the pool. Timeout in seconds; if unspecified, 0.
+     Returns nil if no thingy available.")
+  (release [pool thingy]
+    "Returns a thingy to the pool.")
+  (invalidate [pool thingy]
+    "Tell the pool a thingy is no longer valid."))
 
-;; ----- Connection Pool Initialization -----
+(defrecord FixedQueuePool [queue open close regenerate-interval]
+  Pool
+  (grow [this]
+    (loop []
+      (if-let [thingy (try (open) (catch Throwable t nil))]
+        (.put ^LinkedBlockingQueue queue thingy)
+        (do
+          (Thread/sleep (* 1000 regenerate-interval))
+          (recur)))))
 
-(defn start*
-  "Internal function for starting a pool. Use start instead."
-  [low high init]
-  {:pre [(>= high low) (pos? low) init]} ; high and low must be sane, and the init function can't be nil
-  (let [pool {:init init :low low :high high :connections #{}}]
-    (reduce (fn [p _] (assoc-new-connection p)) pool (range low))))
+  (claim [this]
+    (claim this nil))
 
-;; ----- Get and Release Connections from the Pool -----
+  (claim [this timeout]
+    (let [timeout (* 1000 (or timeout 0))]
+      (or
+       (try
+         (.poll ^LinkedBlockingQueue queue timeout TimeUnit/MILLISECONDS)
+         (catch java.lang.InterruptedException e
+           nil))
+       (throw
+        (ex-info (str "Couldn't claim a resource from the pool within " timeout " ms"))))))
 
-(defn get-connection
-  "Low level function for getting process. Use with-connection macro instead."
-  [{:keys [init high connections] :as pool}]
-  ;; Get a connection that's not busy if we can
-  (trace "Getting DB pool connection from pool size" (count (:connections pool)) "of" high "." )
-  (let [free-connections (remove :busy connections) ; all non-busy connections
-        connection (if (seq free-connections) ; if there are some
-                    (first free-connections) ; get the first one
-                    (when (> high (count connections)) ; if not, can the pool still grow?
-                      (new-connection init connections))) ; create a new connection for the pool
-        ;; mark the connection as busy
-        connection-after (assoc connection :busy true)
-        ;; replace the free connection with the busy one
-        connections (-> connections (disj connection) (conj connection-after))
-        ;; if we got a connection, then update the state of the pool
-        pool (if connection
-                (assoc pool :connections connections)
-                pool)]
+  (release [this thingy]
+    (when thingy
+      (.put ^LinkedBlockingQueue queue thingy)))
 
-    ;; handle the case of no connection available
-    (if-not connection (let [msg "No connection available from DB pool"]
-                        (error msg)
-                        (throw (RuntimeException. msg))))
+  (invalidate [this thingy]
+    (when thingy
+      (try (close thingy)
+           (catch Throwable t
+             (timbre/warn t "Closing" thingy "threw")))
+      (future (grow this)))))
 
-    ;; return the new state of the pool, and the connection we got
-    (trace "Using connection: " (:id connection))
-    [pool connection]))
+(defn fixed-pool
+  "A fixed pool of thingys. (open) is called to generate a thingy. (close
+  thingy) is called when a thingy is invalidated. When thingys are invalidated,
+  the pool will immediately try to open a new one; if open throws or returns
+  nil, the pool will sleep for regenerate-interval seconds before retrying
+  (open).
+  :regenerate-interval    How long to wait between retrying (open).
+  :size                   Number of thingys in the pool.
+  :block-start            Should (fixed-pool) wait until the pool is full
+                          before returning?
+  Note that fixed-pool is correct only if every successful (claim) is followed
+  by exactly one of either (invalidate) or (release). If calls are unbalanced;
+  e.g. resources are not released, doubly released, or released *and*
+  invalidated, starvation or unbounded blocking could occur. (with-pool)
+  provides this guarantee."
+  ([open]
+   (fixed-pool open {}))
+  ([open opts]
+   (fixed-pool open identity opts))
+  ([open close opts]
+   (let [^int size            (or (:size opts) (* 2 (.availableProcessors
+                                                      (Runtime/getRuntime))))
+         regenerate-interval  (or (:regenerate-interval opts) 5)
+         block-start          (get opts :block-start true)
+         pool (FixedQueuePool.
+                (LinkedBlockingQueue. size)
+                open
+                close
+                regenerate-interval)
+         openers (doall
+                   (map (fn open-pool [_]
+                          (future (grow pool)))
+                        (range size)))]
+     (when block-start
+       (doseq [worker openers] @worker))
+     pool)))
 
-(defn release-connection
-  "Low level function for releasing. Use with-connection macro instead."
-  [{:keys [connections] :as pool} {res-id :id :as connection}]
-  ;; Get the connection to be released from the pool
-  (trace "Releasing connection:" res-id)
-  (let [busy-connection (first (filter #(= (:id %) res-id) connections))
-        connections (disj connections busy-connection) ; out of the pool
-        connections (conj connections connection)] ; back into the pool w/o busy
-    (assoc pool :connections connections)))
+;; --- Handy macro to claim and release things from pool
 
-;; ----- External API -----
+(defmacro with-pool
+  "Evaluates body in a try expression with a symbol 'thingy claimed from the
+  given pool, with specified claim timeout. Releases thingy at the end of the
+  body, or if an exception is thrown, invalidates them and rethrows. Example:
+  ; With client, taken from connection-pool, waiting 5 seconds to claim, send
+  ; client a message.
+  (with-pool [client connection-pool 5]
+    (send client a-message))"
+  [[thingy pool timeout] & body]
+  ;; Destructuring bind could change nil to a, say, vector, and cause unbalanced claim/release.
+  `(let [thingy# (claim ~pool ~timeout)
+         ~thingy thingy#]
+     (try
+       (let [res# (do ~@body)]
+         (release ~pool thingy#)
+         res#)
+       (catch Throwable t#
+         (invalidate ~pool thingy#)
+         (throw t#)))))
 
-(defn start
-  "Start a connection pool. Uses pool size from the config or optionally passed in
-  `low` and `high` pool size. Returns `:ok` if pool starts, or `:started` if the
-  pool was already started."
-  ([] (start config/db-pool-size config/db-pool-size))
-  ([low high]
-    (info "Starting DB pool with low:" low " high:" high)
-    (reset! rethinkdb-pool (start* low high init-connection))
-    :ok))
+;; --- Define stateful pool & functions to rebuild
 
-(defmacro with-connection
-  "Get a connection from a pool, bind it to connection, so you can use it in body,
-   after body finish, the connection will be returned to the pool."
-  [[connection] & body]
-  `(do
-    (trace "Starting DB pool connection macro.")
-    (locking rethinkdb-pool
-      (when (nil? @rethinkdb-pool) (debug "DB pool not started. Starting.") (start)))
-    (let [[new-pool# conn#] (get-connection (deref rethinkdb-pool))]
-      (reset! rethinkdb-pool new-pool#)
-      (try
-        (let [~connection (:connection conn#)]
-          (do ~@body))
-        (finally
-          (if conn# (reset! rethinkdb-pool (release-connection (deref rethinkdb-pool) conn#))))))))
+(def rethinkdb-pool
+  (fixed-pool init-connection close-conn {:size (or 5 config/db-pool-size)}))
+
+(defn rebuild-pool!
+  "Rebuild the entire pool. This is not atomic so other threads
+  taking connections at the same time may get stale ones.
+  Those are invalidated as soon as they cause an exception."
+  [pool]
+  (dotimes [i (.size (:queue pool))]
+    (invalidate pool (claim pool))))
+
+(comment
+  (.size (:queue rethinkdb-pool))
+
+  (rebuild-pool rethinkdb-pool)
+
+  (def c (.poll (:queue rethinkdb-pool)))
+
+  (deref c)
+
+  (rethinkdb.core/close c))

--- a/src/open_company/db/pool.clj
+++ b/src/open_company/db/pool.clj
@@ -19,8 +19,8 @@
   (grow [pool]
     "Adds an element to the pool.")
   (claim [pool] [pool timeout]
-    "Take a thingy from the pool. Timeout in seconds; if unspecified, 0.
-     Returns nil if no thingy available.")
+    "Take a thingy from the pool. Timeout of getting a thingy from the pool in seconds (not of using a thingy
+     from the pool); if unspecified, 0. Returns nil if no thingy available.")
   (release [pool thingy]
     "Returns a thingy to the pool.")
   (invalidate [pool thingy]

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -144,9 +144,9 @@
     (select-keys [:avatar :image :user-id :name])
     (clojure.set/rename-keys {:avatar :image})))
 
-;; ----- Timeouts ----
+;; ----- DB Access Timeouts ----
 
-(def default-timeout 300)
+(def default-timeout 1000) ; 1 sec
 
 (defmacro with-timeout
   "A basic macro to wrap things in a timeout.

--- a/src/open_company/util/sample_data.clj
+++ b/src/open_company/util/sample_data.clj
@@ -93,7 +93,6 @@
        (s/join \newline errors)))
 
 (defn -main [& args]
-  (pool/start)
   (let [{:keys [options arguments errors summary]} (parse-opts args cli-options)]
     ;; Handle help and error conditions
     (cond

--- a/src/open_company/util/sample_data.clj
+++ b/src/open_company/util/sample_data.clj
@@ -3,7 +3,6 @@
   (:require [clojure.string :as s]
             [clojure.tools.cli :refer (parse-opts)]
             [defun :refer (defun-)]
-            [open-company.db.pool :as pool]
             [open-company.resources.common :as common]
             [open-company.resources.company :as company]
             [open-company.resources.section :as section])

--- a/test/open_company/lib/db.clj
+++ b/test/open_company/lib/db.clj
@@ -9,8 +9,7 @@
 (defn test-startup
   "Start a minimal DB pool to support running sequential tests."
   []
-  (reset! pool/rethinkdb-pool nil)
-  (pool/start 1 1))
+  (pool/rebuild-pool! pool/rethinkdb-pool))
 
 (defn postdate
   "Push the timestamps of the specified section back to 1 second before the collapse-edit-time time limit."

--- a/test/open_company/unit/db/pool.clj
+++ b/test/open_company/unit/db/pool.clj
@@ -5,134 +5,134 @@
 (def counter (atom 0))
 
 ;; simple init function that makes each resource a unique ascending int
-(def init (fn [] (swap! counter inc)))
+;; (def init (fn [] (swap! counter inc)))
 
-(def rethinkdb-connection-keys #{:ch :db :in :loops :out :pub :r-ch :socket :token :waiting})
+;; (def rethinkdb-connection-keys #{:ch :db :in :loops :out :pub :r-ch :socket :token :waiting})
 
-(defn reset-pool [new-pool] (reset! pool/rethinkdb-pool new-pool))
+;; (defn reset-pool [new-pool] (reset! pool/rethinkdb-pool new-pool))
 
-(with-state-changes [(before :facts (reset-pool nil))]
+;; (with-state-changes [(before :facts (reset-pool nil))]
 
-  (facts "about resource pools"
+;;   (facts "about resource pools"
 
-    (facts "when failing to start resource pools"
+;;     (facts "when failing to start resource pools"
 
-      ;; Pool size not positive
-      (pool/start* 0 0 init) => (throws AssertionError)
+;;       ;; Pool size not positive
+;;       (pool/start* 0 0 init) => (throws AssertionError)
 
-      ;; Pool size not sane
-      (pool/start* 5 3 init) => (throws AssertionError)
+;;       ;; Pool size not sane
+;;       (pool/start* 5 3 init) => (throws AssertionError)
 
-      ;; No init
-      (pool/start* 3 3 nil) => (throws AssertionError))
+;;       ;; No init
+;;       (pool/start* 3 3 nil) => (throws AssertionError))
 
-    (with-state-changes [(before :facts (reset! counter 0))]
+;;     (with-state-changes [(before :facts (reset! counter 0))]
 
-      (facts "when starting resource pools"
+;;       (facts "when starting resource pools"
 
-        (fact "pool starts at low size, not high size"
+;;         (fact "pool starts at low size, not high size"
 
-          (pool/start* 3 5 init) =>
-            {:connections #{
-              {:id 0 :connection 1}
-              {:id 1 :connection 2}
-              {:id 2 :connection 3}
-            }
-            :high 5
-            :low 3
-            :init init})
+;;           (pool/start* 3 5 init) =>
+;;             {:connections #{
+;;               {:id 0 :connection 1}
+;;               {:id 1 :connection 2}
+;;               {:id 2 :connection 3}
+;;             }
+;;             :high 5
+;;             :low 3
+;;             :init init})
 
-        (fact "pool knows when low and high size are the same"
+;;         (fact "pool knows when low and high size are the same"
 
-          (pool/start* 5 5 init) =>
-            {:connections #{
-              {:id 0 :connection 1}
-              {:id 1 :connection 2}
-              {:id 2 :connection 3}
-              {:id 3 :connection 4}
-              {:id 4 :connection 5}
-            }
-            :high 5
-            :low 5
-            :init init})))
+;;           (pool/start* 5 5 init) =>
+;;             {:connections #{
+;;               {:id 0 :connection 1}
+;;               {:id 1 :connection 2}
+;;               {:id 2 :connection 3}
+;;               {:id 3 :connection 4}
+;;               {:id 4 :connection 5}
+;;             }
+;;             :high 5
+;;             :low 5
+;;             :init init})))
 
-    (facts "when using resources"
+;;     (facts "when using resources"
 
-      (fact "it provides 2 resources, then no more"
+;;       (fact "it provides 2 resources, then no more"
 
-        (pool/start 2 2)
+;;         (pool/start 2 2)
 
-        (pool/with-connection [conn]
-          (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-          (pool/with-connection [conn]
-            (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-            (pool/with-connection [conn] (println conn)) =>
-              (throws RuntimeException "No connection available from DB pool")))) ; no more connections
+;;         (pool/with-connection [conn]
+;;           (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;           (pool/with-connection [conn]
+;;             (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;             (pool/with-connection [conn] (println conn)) =>
+;;               (throws RuntimeException "No connection available from DB pool")))) ; no more connections
 
-      (fact "it grows from 2 to 4, then no more"
+;;       (fact "it grows from 2 to 4, then no more"
 
-        (pool/start 2 4)
+;;         (pool/start 2 4)
 
-        (pool/with-connection [conn]
-          (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-          (pool/with-connection [conn]
-            (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-            (pool/with-connection [conn]
-              (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-              (pool/with-connection [conn]
-                (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-                (pool/with-connection [conn] (println conn)) =>
-                  (throws RuntimeException "No connection available from DB pool"))))))
+;;         (pool/with-connection [conn]
+;;           (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;           (pool/with-connection [conn]
+;;             (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;             (pool/with-connection [conn]
+;;               (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;               (pool/with-connection [conn]
+;;                 (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;                 (pool/with-connection [conn] (println conn)) =>
+;;                   (throws RuntimeException "No connection available from DB pool"))))))
 
 
-      (fact "it recovers from no more resources"
+;;       (fact "it recovers from no more resources"
 
-        (pool/start 2 2)
+;;         (pool/start 2 2)
 
-        (pool/with-connection [conn]
-          (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-          (pool/with-connection [conn]
-            (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
-            (pool/with-connection [conn] (println conn)) =>
-              (throws RuntimeException "No connection available from DB pool") ; no more connections
-            (pool/with-connection [conn] (println conn)) =>
-              (throws RuntimeException "No connection available from DB pool") ; no more connections
-            (pool/with-connection [conn] (println conn)) =>
-              (throws RuntimeException "No connection available from DB pool")) ; no more connections
-          (pool/with-connection [conn]
-            (keys @conn) => (just rethinkdb-connection-keys))))))) ; valid connection
+;;         (pool/with-connection [conn]
+;;           (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;           (pool/with-connection [conn]
+;;             (keys @conn) => (just rethinkdb-connection-keys) ; valid connection
+;;             (pool/with-connection [conn] (println conn)) =>
+;;               (throws RuntimeException "No connection available from DB pool") ; no more connections
+;;             (pool/with-connection [conn] (println conn)) =>
+;;               (throws RuntimeException "No connection available from DB pool") ; no more connections
+;;             (pool/with-connection [conn] (println conn)) =>
+;;               (throws RuntimeException "No connection available from DB pool")) ; no more connections
+;;           (pool/with-connection [conn]
+;;             (keys @conn) => (just rethinkdb-connection-keys))))))) ; valid connection
 
-(facts "about resource pools"
+;; (facts "about resource pools"
 
-  (fact "it provides the same resource sequentially"
+;;   (fact "it provides the same resource sequentially"
 
-    (reset! counter 0)
-    (reset-pool (pool/start* 2 4 init))
+;;     (reset! counter 0)
+;;     (reset-pool (pool/start* 2 4 init))
 
-    (pool/with-connection [res]
-      res => 1
-      (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}])))
+;;     (pool/with-connection [res]
+;;       res => 1
+;;       (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}])))
 
-    (pool/with-connection [res]
-      res => 1
-      (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}]))
+;;     (pool/with-connection [res]
+;;       res => 1
+;;       (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}]))
 
-    (pool/with-connection [res]
-      res => 1
-      (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}]))
+;;     (pool/with-connection [res]
+;;       res => 1
+;;       (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}]))
 
-    (pool/with-connection [res]
-      res => 1
-      (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}])
-      (pool/with-connection [res]
-        res => 2
-        (:connections @pool/rethinkdb-pool) =>
-          (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2 :busy true}])))
+;;     (pool/with-connection [res]
+;;       res => 1
+;;       (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}])
+;;       (pool/with-connection [res]
+;;         res => 2
+;;         (:connections @pool/rethinkdb-pool) =>
+;;           (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2 :busy true}])))
 
-    (pool/with-connection [res]
-      res => 1
-      (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}])
-      (pool/with-connection [res]
-        res => 2
-        (:connections @pool/rethinkdb-pool) =>
-          (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2 :busy true}]))))
+;;     (pool/with-connection [res]
+;;       res => 1
+;;       (:connections @pool/rethinkdb-pool) => (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2}])
+;;       (pool/with-connection [res]
+;;         res => 2
+;;         (:connections @pool/rethinkdb-pool) =>
+;;           (just [{:id 0 :connection 1 :busy true} {:id 1 :connection 2 :busy true}]))))

--- a/test/open_company/unit/db/pool.clj
+++ b/test/open_company/unit/db/pool.clj
@@ -3,83 +3,83 @@
             [open-company.db.pool :as p]))
 
 (facts "about claiming & releasing pool inventory"
-         (let [x (atom 0)
-               pool (p/fixed-pool #(swap! x inc) {:size 2 :block-start true})
-               ; Claim both elements
-               a  (p/claim pool)
-               b  (p/claim pool)
-               ; Pool is empty; should throw
-               c  (try (p/claim pool 2/1000)
-                       (catch Exception e
-                         (.getMessage e)))
-               a' (p/release pool a)
-               ; Should re-acquire a
-               d  (p/claim pool)
-               ; Empty
-               e  (try (p/claim pool)
-                       (catch Exception _ :timeout))
-               b' (p/release pool b)
-               ; Re-acquire b
-               f  (p/claim pool)]
-           #{a b} => #{1 2}
-           c => "Couldn't claim a resource from the pool within 2 ms"
-           a => d
-           e => :timeout
-           b => f
-           ; Shouldn't have (open)'d more than twice.
-           @x => 2))
+  (let [x (atom 0)
+        pool (p/fixed-pool #(swap! x inc) {:size 2 :block-start true})
+        ;; Claim both elements
+        a  (p/claim pool)
+        b  (p/claim pool)
+        ;; Pool is empty; should throw
+        c  (try (p/claim pool 2/1000)
+                (catch Exception e
+                  (.getMessage e)))
+        a' (p/release pool a)
+        ;; Should re-acquire a
+        d  (p/claim pool)
+        ;; Empty
+        e  (try (p/claim pool)
+                (catch Exception _ :timeout))
+        b' (p/release pool b)
+        ;; Re-acquire b
+        f  (p/claim pool)]
+    #{a b} => #{1 2}
+    c => "Couldn't claim a resource from the pool within 2 ms"
+    a => d
+    e => :timeout
+    b => f
+    ;; Shouldn't have (open)'d more than twice.
+    @x => 2))
 
 (facts "about claiming and invalidating"
-         (let [x (atom 0)
-               pool (p/fixed-pool #(swap! x inc) {:size 2 :block-start true})
-               a  (p/claim pool)
-               a' (p/invalidate pool a)
-               b  (p/claim pool)
+  (let [x (atom 0)
+        pool (p/fixed-pool #(swap! x inc) {:size 2 :block-start true})
+        a  (p/claim pool)
+        a' (p/invalidate pool a)
+        b  (p/claim pool)
 
-               b' (p/invalidate pool b)
-               c  (p/claim pool 1)
-               d  (p/claim pool 1)
-               e  (try (p/claim pool 1) (catch Exception e nil))
-               c' (p/invalidate pool c)
-               d' (p/invalidate pool d)
-               ; Invalidate nil should be a noop
-               e' (p/invalidate pool e)]
-           ; Wait for futures.
-           a' => truthy
-           b' => truthy
-           c' => truthy
-           d' => truthy
-           e' => nil
+        b' (p/invalidate pool b)
+        c  (p/claim pool 1)
+        d  (p/claim pool 1)
+        e  (try (p/claim pool 1) (catch Exception e nil))
+        c' (p/invalidate pool c)
+        d' (p/invalidate pool d)
+        ;; Invalidate nil should be a noop
+        e' (p/invalidate pool e)]
+    ;; Wait for futures.
+    a' => truthy
+    b' => truthy
+    c' => truthy
+    d' => truthy
+    e' => nil
 
-           (dorun (map deref [a' b' c' d']))
+    (dorun (map deref [a' b' c' d']))
 
-           a => 1
-           b => 2
-           #{a b c d} #{1 2 3 4}
-           e => nil
-           ; Should have opened twice to start and 4 times after invalidations.
-           @x => 6))
+    a => 1
+    b => 2
+    #{a b c d} #{1 2 3 4}
+    e => nil
+    ;; Should have opened twice to start and 4 times after invalidations.
+    @x => 6))
 
 (facts "about with-pool macro"
-         (let [x (atom 0)
-               pool (p/fixed-pool #(swap! x inc) {:size 1 :block-start true})]
+  (let [x (atom 0)
+        pool (p/fixed-pool #(swap! x inc) {:size 1 :block-start true})]
 
-           ; Regular claim
-           (let [a (p/with-pool [a pool] a)]
-             a => 1
-             @x => 1)
+    ;; Regular claim
+    (let [a (p/with-pool [a pool] a)]
+      a => 1
+      @x => 1)
 
-           ; With-pool should have released.
-           (let [a (p/claim pool)]
-             a => 1
-             (p/release pool a))
+    ;; With-pool should have released.
+    (let [a (p/claim pool)]
+      a => 1
+      (p/release pool a))
 
-           ; Throwing errors
-           (p/with-pool [b pool]
-             b => 1
-             (throw (RuntimeException. "whoops")))
-           => (throws RuntimeException)
+    ;; Throwing errors
+    (p/with-pool [b pool]
+      b => 1
+      (throw (RuntimeException. "whoops")))
+    => (throws RuntimeException)
 
-           ; Pool should have regenerated.
-           (Thread/sleep 250)
-           @x => 2))
+    ;; Pool should have regenerated.
+    (Thread/sleep 250)
+    @x => 2))

--- a/test/open_company/unit/resources/common.clj
+++ b/test/open_company/unit/resources/common.clj
@@ -4,6 +4,6 @@
 
 (facts "about with-timeout macro"
   (let [s "result"] 
-    (co/with-timeout 100 s) => s
-    (co/with-timeout 100 (do (Thread/sleep 90) s) => s)
-    (co/with-timeout 100 (do (Thread/sleep 110) s)) => (throws Exception)))
+    (co/with-timeout 50 s) => s
+    (co/with-timeout 50 (do (Thread/sleep 40) s) => s)
+    (co/with-timeout 50 (do (Thread/sleep 60) s)) => (throws Exception)))

--- a/test/open_company/unit/resources/common.clj
+++ b/test/open_company/unit/resources/common.clj
@@ -1,0 +1,9 @@
+(ns open-company.unit.resources.common
+  (:require [open-company.resources.common :as co]
+            [midje.sweet :refer :all]))
+
+(facts "about with-timeout macro"
+  (let [s "result"] 
+    (co/with-timeout 100 s) => s
+    (co/with-timeout 100 (do (Thread/sleep 90) s) => s)
+    (co/with-timeout 100 (do (Thread/sleep 110) s)) => (throws Exception)))


### PR DESCRIPTION
This replaces the existing connection pooling implementation with one that is capable of invalidating connections.

Also using `open-company.db.pool/rebuild-pool!` it is now possible to rebuild the pool in the case RethinkDB has been restarted or similar.


### To Test ([trello card](https://trello.com/c/5ebQjwZS/208-db-pool-improvements))

- Run tests
- Review changes in inidividual files
- Review `default-timeout` (300ms)



Addressing the individual points from the [trello card](https://trello.com/c/5ebQjwZS/208-db-pool-improvements):


---
**return other than :ok for start if it fails to start**

A pool can always be started. If the pool fails to create a resource it will try again in a specified interval (default: 5s). If the pool continously fails to create resources any attempts to claim a resource from the pool will throw an exception.

---
**check for validity of connections (bounce rethinkDB to force them to go bad)**

I looked for a way to check if a connection is healthy but couldn't find any. 
If a connection is bad (causes an exception) the `with-pool` macro will invalidate that resource.
To invalidate all connections there is `open-company.db.pool/rebuild-pool!`.

---
**reconnect them**

Handled by the above(?)

---
**block or otherwise handle the pool being out of connections**

The pool will throw exceptions if no resources are available. This can be mitigated by supplying a timeout (default: 0ms)

---
**log much**

- [x] add a bunch of `timbre/trace` statements

---

**DB pool doesn’t work at 50 connections (server) or 60 connections (locally), where is this limit from?**

There are no hard limits from RethinkDB so I'm not sure what's causing this. @belucid What exactly does "doesn't work" mean here?

@martinklepsch this was the limit in core.async based on CPU cores that you discovered.

---
**API server is sometimes unresponsive after a cold start (any requests that access the DB block indefinitely), and are only fixed by restarting the API server**

Testing this stuff on the REPL I often noticed that closing connections would block indefinitely. On other occasions it just worked again. I guess we should look at this again after we added more logging.

Other notes:

- [x] copy over test suite from riemann project(?)
