### PR TITLE
Derive the default DB pool size from core async thread limits.

### DIFF
--- a/src/open_company/config.clj
+++ b/src/open_company/config.clj
@@ -10,12 +10,17 @@
   [val]
   (boolean (Boolean/valueOf val)))
 
+;; ----- System -----
+
+(defonce processors (.availableProcessors (Runtime/getRuntime)))
+(defonce core-async-limit (+ 42 (* 2 processors)))
+
 ;; ----- RethinkDB -----
 
 (defonce db-host (or (env :db-host) "localhost"))
 (defonce db-port (or (env :db-port) 28015))
 (defonce db-name (or (env :db-name) "open_company"))
-(defonce db-pool-size (or (env :db-pool-size) 40))
+(defonce db-pool-size (or (env :db-pool-size) (- core-async-limit 21))) ; conservative with the core.async limit
 
 (defonce db-map {:host db-host :port db-port :db db-name})
 (defonce db-options (flatten (vec db-map))) ; k/v sequence as clj-rethinkdb wants it
@@ -40,7 +45,8 @@
 
 ;; ----- OpenCompany -----
 
-(defonce collapse-edit-time (or (env :open-company-collapse-edit-time) (* 24 60))) ; in minutes
+;; how long to wait before a sequential edit by the same author is considered a new version
+(defonce collapse-edit-time (or (env :open-company-collapse-edit-time) (* 24 60))) ; 24 hours in minutes
 
 (defonce sections (json/decode (slurp (clojure.java.io/resource "open_company/assets/sections.json"))))
 


### PR DESCRIPTION
https://trello.com/c/scAtiIZc

Implement @martinklepsch suggestion of limiting pool size to core.async limits (for now, until driver is fixed). 

Also fixes the bug of a race condition starting the DB pool which often results in multiple pools from a cold start and the dreaded DB thread lockup of death problem.

To test:

0- Review the code
1- Set your logging level to `trace` in config.clj
2- Calculate: (your machine's cores * 2) + 21
2- Start the API server and note the DB Pool size output, does it match your calculation?
3- Hit your cold API server with your warm web app (just cmd-R a local OC web page), this should result in multiple API requests in very close proximity
4- No lockup?
5- Look at your `/tmp/oc-api.log` file, it has just one of each of these, not 2 like this?

```
16-02-24 13:04:54 Seans-Mac-Pro.local TRACE [open-company.resources.common] - Starting DB pool connection macro.
16-02-24 13:04:54 Seans-Mac-Pro.local TRACE [open-company.resources.common] - Starting DB pool connection macro.
16-02-24 13:04:54 Seans-Mac-Pro.local DEBUG [open-company.resources.common] - DB pool not started. Starting.
16-02-24 13:04:54 Seans-Mac-Pro.local DEBUG [open-company.resources.common] - DB pool not started. Starting.
```

6- Sweet hotness that's good stuff. Merge!
7- Learn to play Jazz trombone