### PR TITLE
Minor API changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,9 +234,9 @@ Then enter these commands one-by-one, noting the output:
 (company/list-companies)
 
 ;; Get a company
-(company/get-company "blank-inc")
-(company/get-company "open")
-(company/get-company "buffer")
+(aprint (company/get-company "blank-inc"))
+(aprint (company/get-company "open"))
+(aprint (company/get-company "buffer"))
 
 ;; Create/update a section
 (section/put-section "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]} author)
@@ -254,27 +254,32 @@ Then enter these commands one-by-one, noting the output:
   {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
   {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}
   {:period "2015-11" :cash 51125 :revenue 50 :costs 7912}]
-  :notes {:body "We got our second customer! Revenue FTW!"}} author)
+  :notes {:body "We got our second customer! More revenue FTW!"}} author)
+(aprint (company/get-company "blank-inc"))
 
 (section/put-section "buffer" :update {:headline "It's all meh."} author)
+(aprint (company/get-company "buffer"))
 
 ;; Get a section
-(section/get-section "transparency" :finances)
-(section/get-section "buffer" :update)
-(section/get-section "buffer" :finances)
+(aprint (section/get-section "blank-inc" :finances))
+(aprint (section/get-section "buffer" :update))
+(aprint (section/get-section "buffer" :finances))
 
 ;; List revisions
-(section/list-revisions "transparency" :finances)
+(section/list-revisions "blank-inc" :finances)
 (section/list-revisions "buffer" :update)
 (section/list-revisions "buffer" :finances)
+;; Note: due to revision collapsing by same author in a short period, there won't as many revisions as you
+;; might think. The introduction of a new note by the same author in finances section of blank-inc causes
+;; a new revision, but the rest of the updates above are collapsed into one revision.
 
 ;; Get revisions
-(section/get-revisions "transparency" :finances)
+(section/get-revisions "blank-inc" :finances)
 (section/get-revisions "buffer" :update)
 (section/get-revisions "buffer" :finances)
 
 ;; Delete a company
-(company/delete-company "transparency")
+(company/delete-company "blank-inc")
 
 ;; Cleanup
 (company/delete-all-companies!)
@@ -329,7 +334,7 @@ curl -i -X GET \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/companies/buffer
+http://localhost:3000/companies/hotel-procrastination
 ```
 
 Update a company with cURL:
@@ -341,79 +346,79 @@ curl -i -X PATCH \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
 --header "Content-Type: application/vnd.open-company.company.v1+json" \
-http://localhost:3000/companies/buffer
+http://localhost:3000/companies/hotel-procrastination
 ```
 
 Revise a section for the company with cURL:
 
 ```console
 curl -i -X PUT \
--d '{"body": "It\u0027s all that and a bag of chips.","title": "Founder\u0027s Update"}' \
+-d '{"body": "It\u0027s all that and a bag of chips.","title": "Founder\u0027s Update", "headline": "Make it rain!"}' \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.section.v1+json" \
 --header "Accept-Charset: utf-8" \
 --header "Content-Type: application/vnd.open-company.section.v1+json" \
-http://localhost:3000/companies/buffer/update
+http://localhost:3000/companies/hotel-procrastination/update
 ```
 
 Reorder a company's sections with cURL:
 
 ```console
 curl -i -X PATCH \
--d '{"sections": {"progress": ["finances", "growth", "team", "product", "marketing", "customer-service", "help", "update"], "company": ["values", "diversity"]}}' \
+-d '{"sections": {"progress": ["growth", "team", "product", "challenges", "update"], "company": ["values", "mission"], "financial": ["finances"]}}' \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
 --header "Content-Type: application/vnd.open-company.company.v1+json" \
-http://localhost:3000/companies/buffer
+http://localhost:3000/companies/hotel-procrastination
 ```
 
-Remove a section from a company sections with cURL:
+Remove sections from a company with cURL:
 
 ```console
 curl -i -X PATCH \
--d '{"sections": {"progress": ["finances", "growth", "team", "product", "customer-service", "help", "update"], "company": ["values", "diversity"]}}' \
+-d '{"sections": {"progress": ["growth", "team", "update"], "company": ["values"], "financial": []}}' \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
 --header "Content-Type: application/vnd.open-company.company.v1+json" \
-http://localhost:3000/companies/buffer
+http://localhost:3000/companies/hotel-procrastination
 ```
 
 Add a section to the company with cURL:
 
 ```console
 curl -i -X PATCH \
--d '{"sections": {"progress": ["finances", "growth", "team", "product", "fundraising", "customer-service", "help", "update"], "company": ["values", "diversity"]}, "fund-raising": {"title": "Fundraising", "body": "No plans. We have enough monies."}}' \
+-d '{"sections": {"progress": ["growth", "customer-service", "team", "update"], "company": ["values"], "financial": []}}' \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
 --header "Content-Type: application/vnd.open-company.company.v1+json" \
-http://localhost:3000/companies/buffer
+http://localhost:3000/companies/hotel-procrastination
 ```
 
 Delete the company with cURL:
 
 ```console
-curl -i -X DELETE
+curl -i -X DELETE \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
-http://localhost:3000/companies/open
+http://localhost:3000/companies/hotel-procrastination
 ```
 
-Then, try (and fail) to get the section and the company with cURL:
+Then, try (and fail) to get a section and the company with cURL:
 
 ```console
 curl -i -X GET \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.section.v1+json" \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/companies/open/update
+http://localhost:3000/companies/hotel-procrastination/update
 
 curl -i -X GET \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
-http://localhost:3000/companies/open
+http://localhost:3000/companies/hotel-procrastination
 ```
 
 ## Import sample data

--- a/REPL_notes.clj
+++ b/REPL_notes.clj
@@ -27,3 +27,54 @@
 (def sections*
   (->> common/sections (map #(assoc % :company-slug "x"))))
 (map #(schema/check common/Section %) sections*)
+
+;; RethinkDB usage
+(def conn [:host "127.0.0.1" :port 28015 :db "open_company"])
+
+(aprint (with-open [c (apply r/connect conn)]
+  (-> (r/table "companies")
+      (r/get "buffer")
+      (r/run c))))
+
+(aprint (with-open [c (apply r/connect conn)]
+  (-> (r/table "companies")
+      (r/get "open-company")
+      (r/run c))))
+
+(with-open [c (apply r/connect conn)]
+  (-> (r/table "companies")
+      (r/get "prompt")
+      (r/update {:mission {:image "https://open-company.s3.amazonaws.com/mission.svg"}})
+      (r/run c)))
+
+(with-open [c (apply r/connect conn)]
+  (-> (r/table "companies")
+      (r/get "open-company")
+      (r/update {:finances {:image "https://open-company.s3.amazonaws.com/finances.svg"}})
+      (r/run c)))
+
+(aprint (with-open [c (apply r/connect conn)]
+  (-> (r/table "sections")
+  (r/get-all ["buffer"] {:index "company-slug"})
+  (r/run c))))
+
+(aprint (with-open [c (apply r/connect conn)]
+  (-> (r/table "sections")
+  (r/get-all [["buffer" "update"]] {:index "company-slug-section-name"})
+  (r/run c))))
+
+(aprint (with-open [c (apply r/connect conn)]
+  (-> (r/table "sections")
+  (r/get-all ["21c9ddd4-6d1c-47a5-b6c1-1308fed08523"] {:index "id"})
+  (r/run c))))
+
+(with-open [c (apply r/connect conn)]
+  (-> (r/table "sections")
+  (r/get-all ["70733852-21f7-4aba-bff6-de93ce699be2"] {:index "id"})
+  (r/update {:image "https://open-company.s3.amazonaws.com/diversity.svg"})
+  (r/run c)))
+
+;; for more RethinkDB help, see:
+;; https://github.com/apa512/clj-rethinkdb
+;; http://apa512.github.io/clj-rethinkdb/
+;; https://rethinkdb.com/api/python/

--- a/opt/samples/bago.edn
+++ b/opt/samples/bago.edn
@@ -28,28 +28,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"

--- a/opt/samples/buffer.edn
+++ b/opt/samples/buffer.edn
@@ -189,28 +189,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"
@@ -526,28 +526,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"
@@ -867,7 +867,7 @@
           }
         ]
         :notes {
-          :body "<p>We're delighted to hit almost $7.5M in annual recurring revenue and be fast moving
+          :body "<p>We're delighted to hit almost $7.5M in ARR and be fast moving
           towards the big $10M ARR milestone.</p>
           <p>As a company, we're starting to feel that some of our recent team growth and structure adjustments
           in the last few months are starting to take effect.</p>"
@@ -888,28 +888,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"
@@ -1288,28 +1288,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"
@@ -1743,28 +1743,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"

--- a/opt/samples/pied-piper.edn
+++ b/opt/samples/pied-piper.edn
@@ -159,28 +159,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"
@@ -366,28 +366,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"
@@ -577,7 +577,7 @@
           }
         ]
         :notes {
-          :body "<p>We're delighted to hit almost $7.5M in annual recurring revenue and be fast moving
+          :body "<p>We're delighted to hit almost $7.5M in ARR and be fast moving
           towards the big $10M ARR milestone.</p>
           <p>As a company, we're starting to feel that some of our recent team growth and structure adjustments
           in the last few months are starting to take effect.</p>"
@@ -598,28 +598,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"
@@ -870,28 +870,28 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total registered users"
+            :name "Total users"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "mau"
-            :name "Monthly active users"
+            :name "MAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "dau"
-            :name "Average daily active users"
+            :name "Avg DAU"
             :interval "monthly"
             :unit "number"
             :target "increase"
           }
           {
             :slug "arr"
-            :name "Annual recurring revenue"
+            :name "ARR"
             :interval "monthly"
             :unit "currency"
             :target "increase"

--- a/project.clj
+++ b/project.clj
@@ -71,7 +71,7 @@
         :open-company-auth-passphrase "this_is_a_dev_secret" ; JWT secret
       }
       :plugins [
-        [lein-bikeshed "0.2.0"] ; Check for code smells https://github.com/dakrone/lein-bikeshed
+        [lein-bikeshed "0.3.0"] ; Check for code smells https://github.com/dakrone/lein-bikeshed
         [lein-checkall "0.1.1"] ; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall
         [lein-pprint "1.1.2"] ; pretty-print the lein project map https://github.com/technomancy/leiningen/tree/master/lein-pprint
         [lein-ancient "0.6.8"] ; Check for outdated dependencies https://github.com/xsc/lein-ancient

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -54,9 +54,9 @@
           (map #(dissoc % :id :section-name))) ; not needed for sections in company
         ; merge the original company with the updated sections & anything other properties they provided 
         with-section-updates (merge original-company (merge company-updates (zipmap section-names updated-sections)))
-        ; get any sections that we used to have, that have been added back in (come back from the dead)
-        with-prior-sections with-section-updates ; TODO
-        ; add in the placeholder sections for any newly added sections
+        ; get any sections that we used to have, that have been added back in (sections back from the dead)
+        with-prior-sections (company/add-prior-sections with-section-updates)
+        ; add in the placeholder sections for any brand new added sections
         with-placeholders (company/add-placeholder-sections with-prior-sections)]
     ;; update the company
     {:updated-company (company/put-company slug with-placeholders user)}))

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -92,10 +92,10 @@
   :exists? (fn [ctx] (get-company slug ctx))
   :known-content-type? (fn [ctx] (common/known-content-type? ctx company-rep/media-type))
 
+  :allowed-methods [:options :get :patch :delete]
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
     :get (fn [ctx] (common/allow-anonymous ctx))
-    :put false
     :patch (fn [ctx] (common/allow-org-members slug ctx))
     :delete (fn [ctx] (common/allow-org-members slug ctx))})
 
@@ -127,7 +127,7 @@
   :available-charsets [common/UTF8]
   :available-media-types (by-method {:get [company-rep/collection-media-type]
                                      :post [company-rep/media-type]})
-  :allowed-methods [:options :post :get]
+  :allowed-methods [:options :get :post]
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
     :get (fn [ctx] (common/allow-anonymous ctx))

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -35,7 +35,7 @@
 (defn- options-for-company [slug ctx]
   (if-let [company (company/get-company slug)]
     (if (common/authorized-to-company? (assoc ctx :company company))
-      (common/options-response [:options :get :put :patch :delete])
+      (common/options-response [:options :get :patch :delete])
       (common/options-response [:options :get]))
     (common/missing-response)))
 
@@ -45,19 +45,21 @@
   (if-let [company (company/get-company slug)]
     {:company company}))
 
-(defn- put-company [slug company user]
-  (let [full-company (assoc company :slug slug)]
-    {:updated-company (company/put-company slug full-company user)}))
-
 (defn- patch-company [slug company-updates user]
   (let [original-company (company/get-company slug)
         section-names (clojure.set/intersection (set (keys company-updates)) common-res/section-names)
+        ; store any new or updated sections that were provided in the company as sections
         updated-sections (->> section-names
-          (map #(section/put-section slug % (company-updates %) user)) ; put each section that's in the patch
+          (map #(section/put-section slug % (company-updates %) user)) ; put each section that's included in the patch
           (map #(dissoc % :id :section-name))) ; not needed for sections in company
-        patch-updates (merge company-updates (zipmap section-names updated-sections))] ; updated sections & anythig else
+        ; merge the original company with the updated sections & anything other properties they provided 
+        with-section-updates (merge original-company (merge company-updates (zipmap section-names updated-sections)))
+        ; get any sections that we used to have, that have been added back in (come back from the dead)
+        with-prior-sections with-section-updates ; TODO
+        ; add in the placeholder sections for any newly added sections
+        with-placeholders (company/add-placeholder-sections with-prior-sections)]
     ;; update the company
-    {:updated-company (company/put-company slug (merge original-company patch-updates) user)}))
+    {:updated-company (company/put-company slug with-placeholders user)}))
 
 ;; ----- Validations -----
 
@@ -84,20 +86,18 @@
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
     :get (fn [ctx] (common/allow-anonymous ctx))
-    :put (fn [ctx] (common/allow-org-members slug ctx))
+    :put false
     :patch (fn [ctx] (common/allow-org-members slug ctx))
     :delete (fn [ctx] (common/allow-org-members slug ctx))})
 
   :processable? (by-method {
     :options true
     :get true
-    :put (fn [ctx] (common/check->liberator true (schema/check common-res/Company (company/->company (add-slug slug (:data ctx)) (:user ctx)))))
     :patch (fn [ctx] true)}) ;; TODO validate for subset of company properties
 
   ;; Handlers
   :handle-ok (by-method {
     :get (fn [ctx] (company-rep/render-company (:company ctx) (common/authorized-to-company? ctx)))
-    :put (fn [ctx] (company-rep/render-company (:updated-company ctx)))
     :patch (fn [ctx] (company-rep/render-company (:updated-company ctx)))})
   :handle-not-acceptable (fn [_] (common/only-accept 406 company-rep/media-type))
   :handle-unsupported-media-type (fn [_] (common/only-accept 415 company-rep/media-type))
@@ -107,12 +107,8 @@
   ;; Delete a company
   :delete! (fn [_] (company/delete-company slug))
 
-  ;; Create or update a company
-  ;; TODO remove possibility to create company
-  :new? (by-method {:put (not (company/get-company slug))})
-  :put! (fn [ctx] (put-company slug (add-slug slug (:data ctx)) (:user ctx)))
-  :patch! (fn [ctx] (patch-company slug (add-slug slug (:data ctx)) (:user ctx)))
-  :handle-created (fn [ctx] (company-location-response (:updated-company ctx))))
+  ;; Update a company
+  :patch! (fn [ctx] (patch-company slug (add-slug slug (:data ctx)) (:user ctx))))
 
 ;; A resource for a list of all the companies the user has access to.
 (defresource company-list
@@ -139,7 +135,7 @@
     :post (fn [ctx] (processable-post-req? ctx))})
 
   :post! (fn [ctx] {:company (-> (company/->company (:data ctx) (:user ctx))
-                                 (company/add-placeholder-sections)
+                                 (company/add-core-placeholder-sections)
                                  (company/create-company!))})
 
   :handle-ok (fn [ctx] (company-rep/render-company-list (:companies ctx)))

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -1,8 +1,7 @@
 (ns open-company.api.companies
   (:require [compojure.core :refer (defroutes ANY OPTIONS GET POST)]
             [liberator.core :refer (defresource by-method)]
-            [clojure.set :as cset]
-            [schema.core :as s]
+            [schema.core :as schema]
             [open-company.config :as config]
             [open-company.api.common :as common]
             [open-company.resources.common :as common-res]
@@ -64,7 +63,7 @@
 
 (defn processable-post-req? [{:keys [user data]}]
   (let [company (company/->company data user)
-        invalid? (s/check common-res/Company company)
+        invalid? (schema/check common-res/Company company)
         slug-taken? (not (company/slug-available? (:slug company)))]
     (cond
       invalid? [false {:reason invalid?}]
@@ -92,7 +91,7 @@
   :processable? (by-method {
     :options true
     :get true
-    :put (fn [ctx] (common/check->liberator true (s/check common-res/Company (company/->company (add-slug slug (:data ctx)) (:user ctx)))))
+    :put (fn [ctx] (common/check->liberator true (schema/check common-res/Company (company/->company (add-slug slug (:data ctx)) (:user ctx)))))
     :patch (fn [ctx] true)}) ;; TODO validate for subset of company properties
 
   ;; Handlers

--- a/src/open_company/api/sections.clj
+++ b/src/open_company/api/sections.clj
@@ -45,7 +45,7 @@
 (defresource section [company-slug section-name as-of]
   common/open-company-anonymous-resource
 
-  :allowed-methods [:options :get :put :patch] ; remove :delete
+  :allowed-methods [:options :get :put :patch]
   :available-media-types [section-rep/media-type]
   :exists? (fn [_] (get-section company-slug section-name as-of))
   :known-content-type? (fn [ctx] (common/known-content-type? ctx section-rep/media-type))
@@ -54,7 +54,9 @@
     :options (fn [ctx] (common/allow-anonymous ctx))
     :get (fn [ctx] (common/allow-anonymous ctx))
     :put (fn [ctx] (common/allow-org-members company-slug ctx))
-    :patch (fn [ctx] (common/allow-org-members company-slug ctx))})
+    :patch (fn [ctx] (common/allow-org-members company-slug ctx))
+    :post false
+    :delete false})
 
   ;; TODO: better handle company slug and section name from body not matching URL
   :processable? (by-method {

--- a/src/open_company/api/sections.clj
+++ b/src/open_company/api/sections.clj
@@ -75,7 +75,9 @@
 
   ;; Handlers
   :handle-ok (by-method {
-    :get (fn [ctx] (section-rep/render-section (:section ctx)))
+    :get (fn [ctx] (section-rep/render-section (:section ctx)
+                                               (common/allow-org-members company-slug ctx)
+                                               (not (nil? as-of))))
     :put (fn [ctx] (section-rep/render-section (:updated-section ctx)))
     :patch (fn [ctx] (section-rep/render-section (:updated-section ctx)))})
   :handle-not-acceptable (fn [_] (common/only-accept 406 section-rep/media-type))

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -9,7 +9,7 @@
             "section-name": "diversity",
             "title": "Diversity",
             "description": "Diversity goals and makeup",
-            "headline": "When it comes to diversity, we...",
+            "headline": "",
             "body": "Discuss company policy and goals around gender, race and ethnicity, age, and sexuality.
             What is the current state of diversity at the company? What are the goals? What changes in hiring,
             culture and retention are you working on to achieve those goals?",
@@ -21,7 +21,7 @@
             "section-name": "privacy",
             "title": "Data Privacy",
             "description": "Company policy on customer information privacy",
-            "headline": "How we protect customer privacy",
+            "headline": "",
             "body": "How does the company use customer data? What regulations such as US HIPAA or European GDPR
             apply to the company? What agreements exist with customers about their data? What
             do these agreements say in Plain English?",
@@ -33,7 +33,7 @@
             "section-name": "values",
             "title": "Values",
             "description": "Core values the company lives by",
-            "headline": "The core values we live by",
+            "headline": "",
             "body": "Core values are the fundamental beliefs of the company. List the company's values. Explain where
             they came from, why they're important, and provide examples of how people can use them to guide their
             decisions, behavior, and actions.",
@@ -45,7 +45,7 @@
             "section-name": "mission",
             "title": "Mission",
             "description": "Why the company exists",
-            "headline": "We exist to...",
+            "headline": "",
             "body": "A short reminder about what it is you do and what's the big idea to make
             sure everyone is aligned to a common purpose.",
             "image": "/img/section-icons/company-mission.svg",
@@ -62,7 +62,7 @@
           "section-name": "update",
           "title": "Founder's Update",
           "description": "Company update",
-          "headline": "Here's what happened during...",
+          "headline": "",
           "body": "Provide an overview of important happenings in the company since the last update.",
           "image": "/img/section-icons/progress-update.svg",
           "core": true
@@ -72,7 +72,7 @@
           "section-name": "highlights",
           "title": "Highlights",
           "description": "Company milestones and accomplishments",
-          "headline": "We made it to...",
+          "headline": "",
           "body": "What new company milestones or accomplishments are you most proud of? List up to three.",
           "image": "/img/section-icons/progress-highlights.svg",
           "core": false
@@ -82,7 +82,7 @@
           "section-name": "growth",
           "title": "Growth",
           "description": "Growth metrics and key performance indicators",
-          "headline": "Watch us grow...",
+          "headline": "",
           "prompt": "Enter the most important growth metric for the stakeholders of your company. You'll be able
           to add more later.",
           "metrics": [
@@ -154,7 +154,7 @@
           "section-name": "challenges",
           "title": "Key Challenges",
           "description": "Challenges facing the company",
-          "headline": "The top challenge we're facing is...",
+          "headline": "",
           "body": "What are you most disappointed about? What’s something you recently learned
           and your plan to fix it going forward? What is the company stuck on? What are the systemic or existential
           threats everyone needs to be focused on?",
@@ -166,7 +166,7 @@
           "section-name": "team",
           "title": "Team and Hiring",
           "description": "Team and hiring update",
-          "headline": "We just hired...",
+          "headline": "",
           "body": "Announce and welcome new hires. Discuss what positions are currently open and what's being
           done to fill them. How many candidates are applying for the positions? Which employees are no longer
           with the company and why they left.",
@@ -178,7 +178,7 @@
           "section-name": "product",
           "title": "Product",
           "description": "Product release and roadmap update",
-          "headline": "We just released...",
+          "headline": "",
           "body": "What tests have you run to validate your product? What did you learn? What's
           shipped recently and how has the roadmap changed? How is the product performing? What's not working? What's
           the evidence you are making something some people love?",
@@ -190,7 +190,7 @@
           "section-name": "customer-service",
           "title": "Customer Service",
           "description": "Customer service update",
-          "headline": "Customers are finding that...",
+          "headline": "",
           "body": "What issues are customers having with your product? How are your service metrics and
           SLA's performing? How are customer service costs and support metrics trending? What new content
           and policies have been created to improve customer success?",
@@ -202,7 +202,7 @@
           "section-name": "marketing",
           "title": "Marketing and Customer Acquisition",
           "description": "Notable marketing activities and results",
-          "headline": "We're trying out...",
+          "headline": "",
           "body": "List any notable marketing activities since the last update. How are the current marketing
           efforts performing? What changes and new activities are planned?",
           "image": "/img/section-icons/progress-marketing.svg",
@@ -213,7 +213,7 @@
           "section-name": "press",
           "title": "Press",
           "description": "Press mentions and PR activities",
-          "headline": "Check out our coverage in...",
+          "headline": "",
           "body": "List any notable press mentions since the last update. Provide an update on PR activities.",
           "image": "/img/section-icons/progress-press.svg",
           "core": false
@@ -223,7 +223,7 @@
           "section-name": "sales",
           "title": "Sales",
           "description": "Notable sales activity and wins and losses",
-          "headline": "We just closed the...",
+          "headline": "",
           "body": "Did you close any notable sales? What opportunities are in the pipeline?",
           "image": "/img/section-icons/progress-sales.svg",
           "core": false
@@ -233,7 +233,7 @@
           "section-name": "business-development",
           "title": "Business Development",
           "description": "Notable partnership activity and new deals",
-          "headline": "We just closed the...",
+          "headline": "",
           "body": "Did you close any notable deals / partnerships? What opportunities are in the pipeline?",
           "image": "/img/section-icons/progress-business-development.svg",
           "core": false
@@ -242,7 +242,7 @@
         {
           "section-name": "help",
           "title": "How You Can Help",
-          "headline": "Just one quick ask, please...",
+          "headline": "",
           "description": "Ask your company stakeholders for help and ideas",
           "body": "Where do you need the most help from your team and investors? Be specific.",
           "image": "/img/section-icons/progress-help.svg",
@@ -252,7 +252,7 @@
         {
           "section-name": "kudos",
           "title": "Kudos",
-          "headline": "A big shout out to...",
+          "headline": "",
           "description": "Celebrate great actions that helped the company",
           "body": "Who went above and beyond to help the company? What did they do?",
           "image": "/img/section-icons/progress-kudos.svg",
@@ -268,7 +268,7 @@
           {
             "section-name": "finances",
             "title": "Finances",
-            "headline": "Cash on hand, burn and runway.",
+            "headline": "",
             "description": "Cash on hand, burn and runway",
             "note": "Provide context about recent changes in company finances with a note.",
             "image": "/img/section-icons/financial-finances.svg",
@@ -278,7 +278,7 @@
           {
             "section-name": "fundraising",
             "title": "Fundraising",
-            "headline": "We're talking to 2 firms about...",
+            "headline": "",
             "description": "Updates on the fundraising process",
             "body": "When are you raising? How much are you raising? What is the purpose of the funds? Link to the
             pitch deck. What’s plan B if you can’t raise as you expect to? Who did you meet with and how did the
@@ -290,7 +290,7 @@
           {
             "section-name": "compensation",
             "title": "Compensation",
-            "headline": "Employee compensation is based on our formula.",
+            "headline": "",
             "description": "Founder, executive and employee compensation practices",
             "body": "Depending on your culture of openness with compensation, you could discuss the
             thought process or formula used to determine salaries / commissions / bonuses / profit share. You may
@@ -306,7 +306,7 @@
             "section-name": "ownership",
             "title": "Ownership",
             "description": "Distribution of company equity",
-            "headline": "Our company is owned by the founders, employees and investors.",
+            "headline": "",
             "body": "How many shares are outstanding? What is the size of the employee option pool? Is there
             a formula used to allocate employee options? What was the value placed on the company, pre/post money,
             during the last raise? Has a 409A valuation been done, what was the value? Provide an easy to understand

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -13,7 +13,7 @@
             "body": "Discuss company policy and goals around gender, race and ethnicity, age, and sexuality.
             What is the current state of diversity at the company? What are the goals? What changes in hiring,
             culture and retention are you working on to achieve those goals?",
-            "image": "/img/section-icons/company-diversity.svg",
+            "image": "https://open-company.s3.amazonaws.com/company-diversity.svg",
             "core": false
           },
 
@@ -25,7 +25,7 @@
             "body": "How does the company use customer data? What regulations such as US HIPAA or European GDPR
             apply to the company? What agreements exist with customers about their data? What
             do these agreements say in Plain English?",
-            "image": "/img/section-icons/company-privacy.svg",
+            "image": "https://open-company.s3.amazonaws.com/company-privacy.svg",
             "core": false
           },
 
@@ -37,7 +37,7 @@
             "body": "Core values are the fundamental beliefs of the company. List the company's values. Explain where
             they came from, why they're important, and provide examples of how people can use them to guide their
             decisions, behavior, and actions.",
-            "image": "/img/section-icons/company-values.svg",
+            "image": "https://open-company.s3.amazonaws.com/company-values.svg",
             "core": true
           },
 
@@ -48,7 +48,7 @@
             "headline": "",
             "body": "A short reminder about what it is you do and what's the big idea to make
             sure everyone is aligned to a common purpose.",
-            "image": "/img/section-icons/company-mission.svg",
+            "image": "https://open-company.s3.amazonaws.com/company-mission.svg",
             "core": true
           }
       ]      
@@ -64,7 +64,7 @@
           "description": "Company update",
           "headline": "",
           "body": "Provide an overview of important happenings in the company since the last update.",
-          "image": "/img/section-icons/progress-update.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-update.svg",
           "core": true
         },
 
@@ -74,7 +74,7 @@
           "description": "Company milestones and accomplishments",
           "headline": "",
           "body": "What new company milestones or accomplishments are you most proud of? List up to three.",
-          "image": "/img/section-icons/progress-highlights.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-highlights.svg",
           "core": false
         },
 
@@ -146,7 +146,7 @@
             "decrease"
           ],
           "note": "Provide context about recent growth with a note.",
-          "image": "/img/section-icons/progress-growth.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-growth.svg",
           "core": true
         },
 
@@ -158,7 +158,7 @@
           "body": "What are you most disappointed about? What’s something you recently learned
           and your plan to fix it going forward? What is the company stuck on? What are the systemic or existential
           threats everyone needs to be focused on?",
-          "image": "/img/section-icons/progress-challenges.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-challenges.svg",
           "core": true
         },
 
@@ -170,7 +170,7 @@
           "body": "Announce and welcome new hires. Discuss what positions are currently open and what's being
           done to fill them. How many candidates are applying for the positions? Which employees are no longer
           with the company and why they left.",
-          "image": "/img/section-icons/progress-team.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-team.svg",
           "core": true
         },
 
@@ -182,7 +182,7 @@
           "body": "What tests have you run to validate your product? What did you learn? What's
           shipped recently and how has the roadmap changed? How is the product performing? What's not working? What's
           the evidence you are making something some people love?",
-          "image": "/img/section-icons/progress-product.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-product.svg",
           "core": true
         },
 
@@ -194,7 +194,7 @@
           "body": "What issues are customers having with your product? How are your service metrics and
           SLA's performing? How are customer service costs and support metrics trending? What new content
           and policies have been created to improve customer success?",
-          "image": "/img/section-icons/progress-customer-service.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-customer-service.svg",
           "core": false
         },
 
@@ -205,7 +205,7 @@
           "headline": "",
           "body": "List any notable marketing activities since the last update. How are the current marketing
           efforts performing? What changes and new activities are planned?",
-          "image": "/img/section-icons/progress-marketing.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-marketing.svg",
           "core": false
         },
 
@@ -215,7 +215,7 @@
           "description": "Press mentions and PR activities",
           "headline": "",
           "body": "List any notable press mentions since the last update. Provide an update on PR activities.",
-          "image": "/img/section-icons/progress-press.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-press.svg",
           "core": false
         },
 
@@ -225,7 +225,7 @@
           "description": "Notable sales activity and wins and losses",
           "headline": "",
           "body": "Did you close any notable sales? What opportunities are in the pipeline?",
-          "image": "/img/section-icons/progress-sales.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-sales.svg",
           "core": false
         },
 
@@ -235,7 +235,7 @@
           "description": "Notable partnership activity and new deals",
           "headline": "",
           "body": "Did you close any notable deals / partnerships? What opportunities are in the pipeline?",
-          "image": "/img/section-icons/progress-business-development.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-business-development.svg",
           "core": false
         },
 
@@ -245,7 +245,7 @@
           "headline": "",
           "description": "Ask your company stakeholders for help and ideas",
           "body": "Where do you need the most help from your team and investors? Be specific.",
-          "image": "/img/section-icons/progress-help.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-help.svg",
           "core": false
         },
 
@@ -255,7 +255,7 @@
           "headline": "",
           "description": "Celebrate great actions that helped the company",
           "body": "Who went above and beyond to help the company? What did they do?",
-          "image": "/img/section-icons/progress-kudos.svg",
+          "image": "https://open-company.s3.amazonaws.com/progress-kudos.svg",
           "core": false
         }
       ]
@@ -271,7 +271,7 @@
             "headline": "",
             "description": "Cash on hand, burn and runway",
             "note": "Provide context about recent changes in company finances with a note.",
-            "image": "/img/section-icons/financial-finances.svg",
+            "image": "https://open-company.s3.amazonaws.com/financial-finances.svg",
             "core": true
           },
 
@@ -283,7 +283,7 @@
             "body": "When are you raising? How much are you raising? What is the purpose of the funds? Link to the
             pitch deck. What’s plan B if you can’t raise as you expect to? Who did you meet with and how did the
             meetings go? After the raise, discuss who the investors are and the terms of the deal.",
-            "image": "/img/section-icons/financial-fundraising.svg",
+            "image": "https://open-company.s3.amazonaws.com/financial-fundraising.svg",
             "core": false
           },
 
@@ -298,7 +298,7 @@
             discuss compensation spend by various departments (engineering, marketing, sales...). If it's part of
             your company culture, you could link to a spreadsheet of all employee salaries. Provide as much
             information as you can in accordance with your company culture.",
-            "image": "/img/section-icons/financial-compensation.svg",
+            "image": "https://open-company.s3.amazonaws.com/financial-compensation.svg",
             "core": false
           },
 
@@ -313,7 +313,7 @@
             summary of the current cap table. What percentage of the company is owned by founders, employees, and
             investors? What terms and preferences do current investors have and what do those terms mean in the
             case of a liquidity event?",
-            "image": "/img/section-icons/financial-ownership.svg",
+            "image": "https://open-company.s3.amazonaws.com/financial-ownership.svg",
             "core": false
           }
       ]

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -13,7 +13,7 @@
           "body": "Does everyone know what they’re fighting for? What is your mission?",
           "image": "https://open-company.s3.amazonaws.com/mission.svg",
           "core": true
-        }
+        },
 
         {
           "section-name": "values",

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -5,52 +5,82 @@
       "title": "Company",
       "sections": [
 
-          {
-            "section-name": "diversity",
-            "title": "Diversity",
-            "description": "Diversity goals and makeup",
-            "headline": "",
-            "body": "Discuss company policy and goals around gender, race and ethnicity, age, and sexuality.
-            What is the current state of diversity at the company? What are the goals? What changes in hiring,
-            culture and retention are you working on to achieve those goals?",
-            "image": "https://open-company.s3.amazonaws.com/company-diversity.svg",
-            "core": false
-          },
+        {
+          "section-name": "mission",
+          "title": "Mission",
+          "description": "Why the company exists",
+          "headline": "",
+          "body": "Does everyone know what they’re fighting for? What is your mission?",
+          "image": "https://open-company.s3.amazonaws.com/mission.svg",
+          "core": true
+        }
 
-          {
-            "section-name": "privacy",
-            "title": "Data Privacy",
-            "description": "Company policy on customer information privacy",
-            "headline": "",
-            "body": "How does the company use customer data? What regulations such as US HIPAA or European GDPR
-            apply to the company? What agreements exist with customers about their data? What
-            do these agreements say in Plain English?",
-            "image": "https://open-company.s3.amazonaws.com/company-privacy.svg",
-            "core": false
-          },
+        {
+          "section-name": "values",
+          "title": "Values",
+          "description": "Core values the company lives by",
+          "headline": "",
+          "body": "Core values are the fundamental beliefs of the company. List the company's values. Explain where
+          they came from, why they're important, and provide examples of how people can use them to guide their
+          decisions, behavior, and actions.",
+          "image": "https://open-company.s3.amazonaws.com/values.svg",
+          "core": true
+        },
 
-          {
-            "section-name": "values",
-            "title": "Values",
-            "description": "Core values the company lives by",
-            "headline": "",
-            "body": "Core values are the fundamental beliefs of the company. List the company's values. Explain where
-            they came from, why they're important, and provide examples of how people can use them to guide their
-            decisions, behavior, and actions.",
-            "image": "https://open-company.s3.amazonaws.com/company-values.svg",
-            "core": true
-          },
+        {
+          "section-name": "diversity",
+          "title": "Diversity",
+          "description": "Diversity goals and makeup",
+          "headline": "",
+          "body": "Discuss company policy and goals around gender, race and ethnicity, age, and sexuality.
+          What is the current state of diversity at the company? What are the goals? What changes in hiring,
+          culture and retention are you working on to achieve those goals?",
+          "image": "https://open-company.s3.amazonaws.com/diversity.svg",
+          "core": false
+        },
 
-          {
-            "section-name": "mission",
-            "title": "Mission",
-            "description": "Why the company exists",
-            "headline": "",
-            "body": "A short reminder about what it is you do and what's the big idea to make
-            sure everyone is aligned to a common purpose.",
-            "image": "https://open-company.s3.amazonaws.com/company-mission.svg",
-            "core": true
-          }
+        {
+          "section-name": "privacy",
+          "title": "Data Privacy",
+          "description": "Company policy on customer information privacy",
+          "headline": "",
+          "body": "How does the company use customer data? What regulations such as US HIPAA or European GDPR
+          apply to the company? What agreements exist with customers about their data? What
+          do these agreements say in Plain English?",
+          "image": "https://open-company.s3.amazonaws.com/privacy.svg",
+          "core": false
+        },
+
+        {
+          "section-name": "competition",
+          "title": "Competition",
+          "headline": "",
+          "description": "Key competitors and competitive threats",
+          "body": "Who are the competitors you’re paying attention to? How do they compare? Besides your competitors,
+          what are the other major external threats to your business?",
+          "image": "https://open-company.s3.amazonaws.com/competition.svg",
+          "core": false
+        },
+
+        {
+          "section-name": "help",
+          "title": "How You Can Help",
+          "headline": "",
+          "description": "Ask your company stakeholders for help and ideas",
+          "body": "Where do you need the most help from your team and investors? Be specific.",
+          "image": "https://open-company.s3.amazonaws.com/help.svg",
+          "core": false
+        },
+
+        {
+          "section-name": "kudos",
+          "title": "Kudos",
+          "headline": "",
+          "description": "Celebrate great actions that helped the company",
+          "body": "Who went above and beyond to help the company? What did they do?",
+          "image": "https://open-company.s3.amazonaws.com/kudos.svg",
+          "core": false
+        }
       ]      
     },
     {
@@ -64,7 +94,7 @@
           "description": "Company update",
           "headline": "",
           "body": "Provide an overview of important happenings in the company since the last update.",
-          "image": "https://open-company.s3.amazonaws.com/progress-update.svg",
+          "image": "https://open-company.s3.amazonaws.com/update.svg",
           "core": true
         },
 
@@ -74,7 +104,7 @@
           "description": "Company milestones and accomplishments",
           "headline": "",
           "body": "What new company milestones or accomplishments are you most proud of? List up to three.",
-          "image": "https://open-company.s3.amazonaws.com/progress-highlights.svg",
+          "image": "https://open-company.s3.amazonaws.com/highlights.svg",
           "core": false
         },
 
@@ -146,7 +176,7 @@
             "decrease"
           ],
           "note": "Provide context about recent growth with a note.",
-          "image": "https://open-company.s3.amazonaws.com/progress-growth.svg",
+          "image": "https://open-company.s3.amazonaws.com/growth.svg",
           "core": true
         },
 
@@ -155,11 +185,21 @@
           "title": "Key Challenges",
           "description": "Challenges facing the company",
           "headline": "",
-          "body": "What are you most disappointed about? What’s something you recently learned
-          and your plan to fix it going forward? What is the company stuck on? What are the systemic or existential
-          threats everyone needs to be focused on?",
-          "image": "https://open-company.s3.amazonaws.com/progress-challenges.svg",
+          "body": "What are you most disappointed about? What’s your plan to fix it going forward?
+          What is the company stuck on? What are the systemic or existential threats everyone needs to be focused on?",
+          "image": "https://open-company.s3.amazonaws.com/challenges.svg",
           "core": true
+        },
+
+       {
+          "section-name": "takeaways",
+          "title": "Key Takeaways",
+          "description": "What we've learned",
+          "headline": "",
+          "body": "What’s something you recently learned about your bunsiness, market, customers, or product?
+          What changes are you making as a result?",
+          "image": "https://open-company.s3.amazonaws.com/takeaways.svg",
+          "core": false
         },
 
         {
@@ -170,7 +210,7 @@
           "body": "Announce and welcome new hires. Discuss what positions are currently open and what's being
           done to fill them. How many candidates are applying for the positions? Which employees are no longer
           with the company and why they left.",
-          "image": "https://open-company.s3.amazonaws.com/progress-team.svg",
+          "image": "https://open-company.s3.amazonaws.com/team.svg",
           "core": true
         },
 
@@ -182,7 +222,7 @@
           "body": "What tests have you run to validate your product? What did you learn? What's
           shipped recently and how has the roadmap changed? How is the product performing? What's not working? What's
           the evidence you are making something some people love?",
-          "image": "https://open-company.s3.amazonaws.com/progress-product.svg",
+          "image": "https://open-company.s3.amazonaws.com/product.svg",
           "core": true
         },
 
@@ -194,7 +234,7 @@
           "body": "What issues are customers having with your product? How are your service metrics and
           SLA's performing? How are customer service costs and support metrics trending? What new content
           and policies have been created to improve customer success?",
-          "image": "https://open-company.s3.amazonaws.com/progress-customer-service.svg",
+          "image": "https://open-company.s3.amazonaws.com/customer-service.svg",
           "core": false
         },
 
@@ -205,7 +245,7 @@
           "headline": "",
           "body": "List any notable marketing activities since the last update. How are the current marketing
           efforts performing? What changes and new activities are planned?",
-          "image": "https://open-company.s3.amazonaws.com/progress-marketing.svg",
+          "image": "https://open-company.s3.amazonaws.com/marketing.svg",
           "core": false
         },
 
@@ -215,7 +255,7 @@
           "description": "Press mentions and PR activities",
           "headline": "",
           "body": "List any notable press mentions since the last update. Provide an update on PR activities.",
-          "image": "https://open-company.s3.amazonaws.com/progress-press.svg",
+          "image": "https://open-company.s3.amazonaws.com/press.svg",
           "core": false
         },
 
@@ -225,7 +265,7 @@
           "description": "Notable sales activity and wins and losses",
           "headline": "",
           "body": "Did you close any notable sales? What opportunities are in the pipeline?",
-          "image": "https://open-company.s3.amazonaws.com/progress-sales.svg",
+          "image": "https://open-company.s3.amazonaws.com/sales.svg",
           "core": false
         },
 
@@ -235,29 +275,10 @@
           "description": "Notable partnership activity and new deals",
           "headline": "",
           "body": "Did you close any notable deals / partnerships? What opportunities are in the pipeline?",
-          "image": "https://open-company.s3.amazonaws.com/progress-business-development.svg",
-          "core": false
-        },
-
-        {
-          "section-name": "help",
-          "title": "How You Can Help",
-          "headline": "",
-          "description": "Ask your company stakeholders for help and ideas",
-          "body": "Where do you need the most help from your team and investors? Be specific.",
-          "image": "https://open-company.s3.amazonaws.com/progress-help.svg",
-          "core": false
-        },
-
-        {
-          "section-name": "kudos",
-          "title": "Kudos",
-          "headline": "",
-          "description": "Celebrate great actions that helped the company",
-          "body": "Who went above and beyond to help the company? What did they do?",
-          "image": "https://open-company.s3.amazonaws.com/progress-kudos.svg",
+          "image": "https://open-company.s3.amazonaws.com/business-development.svg",
           "core": false
         }
+
       ]
     },
     {
@@ -265,57 +286,58 @@
       "title": "Financial",
       "sections": [
 
-          {
-            "section-name": "finances",
-            "title": "Finances",
-            "headline": "",
-            "description": "Cash on hand, burn and runway",
-            "note": "Provide context about recent changes in company finances with a note.",
-            "image": "https://open-company.s3.amazonaws.com/financial-finances.svg",
-            "core": true
-          },
+        {
+          "section-name": "finances",
+          "title": "Finances",
+          "headline": "",
+          "description": "Cash on hand, burn and runway",
+          "note": "Provide context about recent changes in company finances with a note.",
+          "image": "https://open-company.s3.amazonaws.com/finances.svg",
+          "core": true
+        },
 
-          {
-            "section-name": "fundraising",
-            "title": "Fundraising",
-            "headline": "",
-            "description": "Updates on the fundraising process",
-            "body": "When are you raising? How much are you raising? What is the purpose of the funds? Link to the
-            pitch deck. What’s plan B if you can’t raise as you expect to? Who did you meet with and how did the
-            meetings go? After the raise, discuss who the investors are and the terms of the deal.",
-            "image": "https://open-company.s3.amazonaws.com/financial-fundraising.svg",
-            "core": false
-          },
+        {
+          "section-name": "compensation",
+          "title": "Compensation",
+          "headline": "",
+          "description": "Founder, executive and employee compensation practices",
+          "body": "Depending on your culture of openness with compensation, you could discuss the
+          thought process or formula used to determine salaries / commissions / bonuses / profit share. You may
+          want to share the founder/CEO to executive to average employee compensation ratio. You might
+          discuss compensation spend by various departments (engineering, marketing, sales...). If it's part of
+          your company culture, you could link to a spreadsheet of all employee salaries. Provide as much
+          information as you can in accordance with your company culture.",
+          "image": "https://open-company.s3.amazonaws.com/compensation.svg",
+          "core": false
+        },
 
-          {
-            "section-name": "compensation",
-            "title": "Compensation",
-            "headline": "",
-            "description": "Founder, executive and employee compensation practices",
-            "body": "Depending on your culture of openness with compensation, you could discuss the
-            thought process or formula used to determine salaries / commissions / bonuses / profit share. You may
-            want to share the founder/CEO to executive to average employee compensation ratio. You might
-            discuss compensation spend by various departments (engineering, marketing, sales...). If it's part of
-            your company culture, you could link to a spreadsheet of all employee salaries. Provide as much
-            information as you can in accordance with your company culture.",
-            "image": "https://open-company.s3.amazonaws.com/financial-compensation.svg",
-            "core": false
-          },
+        {
+          "section-name": "ownership",
+          "title": "Ownership",
+          "description": "Distribution of company equity",
+          "headline": "",
+          "body": "How many shares are outstanding? What is the size of the employee option pool? Is there
+          a formula used to allocate employee options? What was the value placed on the company, pre/post money,
+          during the last raise? Has a 409A valuation been done, what was the value? Provide an easy to understand
+          summary of the current cap table. What percentage of the company is owned by founders, employees, and
+          investors? What terms and preferences do current investors have and what do those terms mean in the
+          case of a liquidity event?",
+          "image": "https://open-company.s3.amazonaws.com/ownership.svg",
+          "core": false
+        },
 
-          {
-            "section-name": "ownership",
-            "title": "Ownership",
-            "description": "Distribution of company equity",
-            "headline": "",
-            "body": "How many shares are outstanding? What is the size of the employee option pool? Is there
-            a formula used to allocate employee options? What was the value placed on the company, pre/post money,
-            during the last raise? Has a 409A valuation been done, what was the value? Provide an easy to understand
-            summary of the current cap table. What percentage of the company is owned by founders, employees, and
-            investors? What terms and preferences do current investors have and what do those terms mean in the
-            case of a liquidity event?",
-            "image": "https://open-company.s3.amazonaws.com/financial-ownership.svg",
-            "core": false
-          }
+        {
+          "section-name": "fundraising",
+          "title": "Fundraising",
+          "headline": "",
+          "description": "Updates on the fundraising process",
+          "body": "When are you raising? How much are you raising? What is the purpose of the funds? Link to the
+          pitch deck. What’s plan B if you can’t raise as you expect to? Who did you meet with and how did the
+          meetings go? After the raise, discuss who the investors are and the terms of the deal.",
+          "image": "https://open-company.s3.amazonaws.com/fundraising.svg",
+          "core": false
+        }
+
       ]
     }
   ]

--- a/src/open_company/representations/section.clj
+++ b/src/open_company/representations/section.clj
@@ -67,5 +67,9 @@
 
 (defn render-section
   "Create a JSON representation of the section for the REST API"
-  [section]
-  (json/generate-string (section-for-rendering section true) {:pretty true}))
+  ([section]
+    (render-section section true false))
+  ([section authorized]
+    (render-section section authorized false))
+  ([section authorized read-only]
+    (json/generate-string (section-for-rendering section (and authorized (not read-only))) {:pretty true})))

--- a/src/open_company/representations/section.clj
+++ b/src/open_company/representations/section.clj
@@ -52,6 +52,7 @@
   "Remove properties of the section that aren't needed in the REST API representation"
   [section]
   (-> section
+    (dissoc :core)
     (dissoc :id)
     (dissoc :company-slug)
     (dissoc :section-name)))

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -66,16 +66,18 @@
 
 ;; ----- Schemas -----
 
+(def SectionName (schema/pred #(section-names (keyword %))))
+
 (def Slug (schema/pred slug/valid-slug?))
 
 (def SectionsOrder
-  {schema/Keyword [schema/Keyword]})
+  {schema/Keyword [SectionName]})
 
 (def Section
-  {:section-name schema/Keyword
+  {(schema/optional-key :section-name) SectionName
    :title schema/Str
    :description schema/Str
-   :company-slug schema/Str
+   (schema/optional-key :company-slug) schema/Str
    :image schema/Str
    (schema/optional-key :body) schema/Str
    (schema/optional-key :created-at) schema/Str
@@ -93,7 +95,7 @@
           :currency schema/Str
           :org-id schema/Str
           :sections SectionsOrder
-          :categories (schema/pred #(clojure.set/subset? (set %) (set category-names)))
+          :categories (schema/pred #(clojure.set/subset? (set (map keyword %)) (set category-names)))
           (schema/optional-key :home-page) schema/Str
           (schema/optional-key :logo) schema/Str
           (schema/optional-key :created-at) schema/Str

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -49,9 +49,17 @@
 
 ;; All possible sections as a set
 (def sections (set (map #(update % :section-name keyword) (flatten (vals ordered-sections)))))
+
+;; All possible section names as a set
 (def section-names (set (flatten (vals category-section-tree))))
-;; All possible sections as a map
+
+;; All possible sections as a map from their name
 (def sections-by-name (zipmap (map :section-name sections) sections))
+
+(defn section-by-name
+  "Return the canonical placeholder section definition for a named section."
+  [section-name]
+  (sections-by-name (keyword section-name)))
 
 ;; A set of all section names that can contain notes
 (def notes-sections #{:growth :finances})

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -226,6 +226,15 @@
           (r/pluck fields)
           (r/run conn))))))
 
+(defn read-resources-in-order
+  "
+  Given a table name, an index name and value, and a set of fields, retrieve
+  the resources from the database in updated-at property order.
+  "
+  [table-name index-name index-value fields]
+  (updated-at-order
+    (read-resources table-name index-name index-value fields)))
+
 (defn update-resource
   "Given a table name, the name of the primary key, and the original and updated resource,
   update a resource in the DB, returning the property map for the resource."

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -19,7 +19,7 @@
 
 ;; All the categories in default order
 (def categories (:categories (keywordize-keys config/sections)))
-(def category-names (set (map (comp keyword :name) (:categories (keywordize-keys config/sections)))))
+(def category-names (vec (map (comp keyword :name) (:categories (keywordize-keys config/sections)))))
 
 (def ordered-sections
   (into {} (for [{:keys [sections name]} categories]
@@ -93,7 +93,7 @@
           :currency schema/Str
           :org-id schema/Str
           :sections SectionsOrder
-          :categories (schema/pred #(clojure.set/subset? (set %) category-names))
+          :categories (schema/pred #(clojure.set/subset? (set %) (set category-names)))
           (schema/optional-key :home-page) schema/Str
           (schema/optional-key :logo) schema/Str
           (schema/optional-key :created-at) schema/Str

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -62,6 +62,11 @@
   [slug]
   (not (contains? (taken-slugs) slug)))
 
+;; ----- Validations -----
+
+(defn valid-company [slug company]
+  (schema/check common/Company (assoc company :slug slug)))
+
 ;; ----- Company CRUD -----
 
 (defn get-company

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -26,7 +26,7 @@
 (defn- categories-for
   "Add the :categories vector in the company with the definitive initial list of categories."
   [company]
-  (assoc company :categories (vec common/category-names)))
+  (assoc company :categories common/category-names))
 
 (defn- section-list
   "Return the set of section names that are contained in the provided company."

--- a/src/open_company/resources/section.clj
+++ b/src/open_company/resources/section.clj
@@ -202,8 +202,9 @@
   (put-section company-slug (keyword section-name) section user timestamp))
 
   ([company-slug section-name section user timestamp]
-  (let [original-company (company/get-company company-slug)
-        original-section (get-section company-slug section-name)
+  (let [original-company (company/get-company company-slug) ; company before the update
+        original-section (get-section company-slug section-name) ; section before the update
+        template-section (common/section-by-name section-name) ; canonical version of this section
         author (common/author-for-user user)
         updated-section (-> section
           (clean)
@@ -212,6 +213,9 @@
           (assoc :section-name section-name)
           (assoc :author author)
           (assoc :updated-at timestamp)
+          (assoc :image (:image template-section)); read-only property
+          (assoc :description (:description template-section)); read-only property
+          (assoc :headline (or (:headline section) (:headline original-section) (:headline template-section)))
           (update-notes-for (original-company section-name) author timestamp))
         updated-sections (sections-with (:sections original-company) section-name)
         sectioned-company (assoc original-company :sections updated-sections)

--- a/src/open_company/resources/section.clj
+++ b/src/open_company/resources/section.clj
@@ -117,18 +117,15 @@
 
 ;; ----- Section revisions -----
 
-(defn- revisions-for
-  [company-slug section-name fields]
-  (common/updated-at-order
-    (common/read-resources table-name "company-slug-section-name" [company-slug section-name] fields)))
-
 (defn list-revisions
   "Given the slug of the company, and a section name retrieve the timestamps and author of the section revisions."
-  [company-slug section-name] (revisions-for company-slug section-name [:updated-at :author]))
+  [company-slug section-name]
+  (common/read-resources-in-order table-name "company-slug-section-name" [company-slug section-name] [:updated-at :author]))
 
 (defn- list-revision-ids
   "Given the slug of the company, and a section name retrieve the timestamps and database id of the section revisions."
-  [company-slug section-name] (revisions-for company-slug section-name [:updated-at :id]))
+  [company-slug section-name]
+  (common/read-resources-in-order table-name "company-slug-section-name" [company-slug section-name] [:updated-at :id]))
 
 (defn get-revisions
   "Given the slug of the company a section name, and an optional specific updated-at timestamp,

--- a/test/open_company/integration/company/company_create.clj
+++ b/test/open_company/integration/company/company_create.clj
@@ -5,6 +5,7 @@
             [open-company.lib.rest-api-mock :as mock]
             [open-company.lib.hateoas :as hateoas]
             [open-company.lib.resources :as r]
+            [open-company.resources.common :as common]
             [open-company.resources.company :as company]
             [open-company.resources.section :as section]
             [open-company.representations.company :as company-rep]))
@@ -76,7 +77,7 @@
             response (mock/api-request :post "/companies" {:body payload})]
         (:status response) => 422))
 
-    (fact "company can be created with name and description"
+    (fact "a company can be created with just a name and description"
       (let [payload  {:name "Hello World" :description "x"}
             response (mock/api-request :post "/companies" {:body payload})
             body     (mock/body-from-response response)]
@@ -101,14 +102,15 @@
               response (mock/api-request :post "/companies" {:body payload})]
          (:status response) => 422))
       (facts "known user supplied sections"
-        (let [diversity {:title "Diversity" :description "Diversity is important to us." :body "TBD" :section-name "diversity"}
-              payload  {:name "Diverse Co" :description "x" :diversity diversity}
+        (let [diversity {:title "Diversity" :body "TBD" :section-name "diversity"}
+              payload  {:name "Diverse Co" :description "Diversity is important to us." :diversity diversity}
               response (mock/api-request :post "/companies" {:body payload})
               company  (company/get-company "diverse-co")
               sect     (section/get-section "diverse-co" :diversity)]
-          (fact "are added with author and updated-at"
+          (fact "are added with author, updated-at, image and description"
             (:status response) => 201
-            (-> company :diversity :placeholder) => falsey
-            (-> company :diversity :author) => truthy
-            (-> company :diversity :updated-at) => truthy
-            (:description sect) => "Diversity is important to us."))))))
+            (:placeholder sect) => falsey
+            (:author sect) => truthy
+            (:updated-at sect) => truthy
+            (:image sect) => (get-in common/sections-by-name [:diversity :image])
+            (:description sect) => (get-in common/sections-by-name [:diversity :description])))))))

--- a/test/open_company/integration/company/company_create.clj
+++ b/test/open_company/integration/company/company_create.clj
@@ -112,5 +112,5 @@
             (:placeholder sect) => falsey
             (:author sect) => truthy
             (:updated-at sect) => truthy
-            (:image sect) => (get-in common/sections-by-name [:diversity :image])
-            (:description sect) => (get-in common/sections-by-name [:diversity :description])))))))
+            (:image sect) => (:image (common/section-by-name :diversity))
+            (:description sect) => (:description (common/section-by-name :diversity))))))))

--- a/test/open_company/integration/company/company_retrieval.clj
+++ b/test/open_company/integration/company/company_retrieval.clj
@@ -116,7 +116,7 @@
         (:org-id body) => nil ; verify no org-id
         (:categories body) => (map name common/category-names)
         (:sections body) =>
-          {:company ["diversity" "values"], :financial ["finances"], :progress ["update" "team" "help"]}
+          {:company ["help" "diversity" "values"], :financial ["finances"], :progress ["update" "team"]}
         ;; verify section contents
         (:update body) => (contains r/text-section-1)
         (:finances body) => (contains r/finances-section-1)
@@ -136,7 +136,7 @@
             body (mock/body-from-response response)]
         (:status response) => 200
         (:sections body) =>
-          {:company ["diversity" "values"], :financial ["finances"], :progress ["update" "team" "help"]}
+          {:company ["help" "diversity" "values"], :financial ["finances"], :progress ["update" "team"]}
         ;; verify each section has only a self HATEOAS link
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (count (:links (body section-key))) => 1
@@ -152,7 +152,7 @@
             body (mock/body-from-response response)]
         (:status response) => 200
         (:sections body) =>
-          {:company ["diversity" "values"], :financial ["finances"], :progress ["update" "team" "help"]}
+          {:company ["help" "diversity" "values"], :financial ["finances"], :progress ["update" "team"]}
         ;; verify each section has only a self HATEOAS link
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (count (:links (body section-key))) => 1

--- a/test/open_company/integration/company/company_retrieval.clj
+++ b/test/open_company/integration/company/company_retrieval.clj
@@ -51,7 +51,7 @@
 ;; ----- Tests -----
 
 (def limited-options "OPTIONS, GET")
-(def full-options "OPTIONS, GET, PUT, PATCH, DELETE")
+(def full-options "OPTIONS, GET, PATCH, DELETE")
 
 (with-state-changes [(before :facts (do (company/delete-all-companies!)
                                         (company/create-company! (company/->company r/open r/coyote))

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -287,7 +287,11 @@
   
   (facts "about adding sections"
 
-    (future-fact "that don't really exist")
+    (fact "that don't really exist"
+      (let [new-sections {:progress ["health"] :company [] :financial []}
+            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+            body (mock/body-from-response response)]
+        (:status response) => 200))
 
     (facts "without any section content"
     

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -40,7 +40,7 @@
 
 ;; ----- Tests -----
 
-(def categories (map name open-company.resources.common/category-names))
+(def categories (map name common-res/category-names))
 
 (with-state-changes [(around :facts (schema.core/with-fn-validation ?form))
                      (before :facts (do (company/delete-all-companies!)

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -98,8 +98,9 @@
                                    :company ["diversity" "values"]}))
 
     (fact "with no company matching the company slug"
-      (let [new-order {:progress ["team" "update" "finances" "help"]
-                       :company ["diversity" "values"]}
+      (let [new-order {:company ["diversity" "values"]
+                       :progress ["team" "update" "finances" "help"]
+                       :financial []}
             response (mock/api-request :patch (company-rep/url "foo") {:body {:sections new-order}})]
         (:status response) => 404
         (:body response) => "")
@@ -122,7 +123,8 @@
     (facts "when the new order is valid"
 
       (fact "the section order in the progress category can be gently adjusted"
-        (let [new-order {:progress ["team" "update" "finances" "help"]
+        (let [new-order {:progress ["team" "update" "help"]
+                         :financial ["finances"]
                          :company ["diversity" "values"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -131,7 +133,8 @@
           (:sections (company/get-company r/slug)) => new-order))
 
       (fact "the sections order in the progress category can be greatly adjusted"
-        (let [new-order {:progress ["help" "team" "finances" "update"]
+        (let [new-order {:progress ["help" "team" "update"]
+                         :financial ["finances"]
                          :company ["diversity" "values"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -140,7 +143,8 @@
           (:sections (company/get-company r/slug)) => new-order))
 
       (fact "the section order in the company category can be adjusted"
-        (let [new-order {:progress ["update" "finances" "team" "help"]
+        (let [new-order {:progress ["update" "team" "help"]
+                         :financial ["finances"]
                          :company ["values" "diversity"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -149,7 +153,8 @@
           (:sections (company/get-company r/slug)) => new-order))
 
       (fact "the section order in the progress and company category can both be adjusted at once"
-        (let [new-order {:progress ["help" "team" "finances" "update"]
+        (let [new-order {:progress ["help" "team" "update"]
+                         :financial ["finances"]
                          :company ["values" "diversity"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -291,7 +296,7 @@
       (let [new-sections {:progress ["health"] :company [] :financial []}
             response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
             body (mock/body-from-response response)]
-        (:status response) => 200))
+        (:status response) => 422))
 
     (facts "without any section content"
     

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -65,9 +65,9 @@
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:progress ["update" "team" "help"]
-                                   :financial ["finances"]
-                                   :company ["diversity" "values"]}))
+        (:sections db-company) => {:company ["help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]}))
 
     (fact "with no JWToken"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -79,9 +79,9 @@
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:progress ["update" "team" "help"]
-                                   :financial ["finances"]
-                                   :company ["diversity" "values"]}))
+        (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]}))
 
     (fact "with an organization that doesn't match the company"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -93,9 +93,9 @@
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:progress ["update" "team" "help"]
-                                   :financial ["finances"]
-                                   :company ["diversity" "values"]}))
+        (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]}))
 
     (fact "with no company matching the company slug"
       (let [new-order {:company ["diversity" "values"]
@@ -107,18 +107,18 @@
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:progress ["update" "team" "help"]
-                                   :financial ["finances"]
-                                   :company ["diversity" "values"]})))
+        (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]})))
 
   (facts "about section reordering"
 
     ;; verify the initial order
     (let [db-company (company/get-company r/slug)]
       (:categories db-company) => categories
-      (:sections db-company) => {:progress ["update" "team" "help"]
-                                 :financial ["finances"]
-                                 :company ["diversity" "values"]})
+      (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                 :progress ["update" "team"]
+                                 :financial ["finances"]})
 
     (facts "when the new order is valid"
 
@@ -172,14 +172,15 @@
       ;; ensure all placeholder sections are in company
       (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
                               :financial ["finances"]
-                              :company ["values" "mission"]}
+                              :company ["mission" "values"]}
       (:growth company) => truthy
       (:challenges company) => truthy
       (:team company) => truthy
       (:product company) => truthy
       (:mission company) => truthy
-      (let [new-set {:progress ["update" "finances" "help"]
-                     :company ["values"]}
+      (let [new-set {:company ["values"]
+                     :progress ["update" "finances" "help"]
+                     :financial []}
             response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
             body     (mock/body-from-response response)
             company  (company/get-company slug)]
@@ -194,9 +195,9 @@
   (facts "about section removal"
 
     ;; verify the initial set of sections
-    (:sections (company/get-company r/slug)) => {:progress ["update" "team" "help"]
-                                                 :financial ["finances"]
-                                                 :company ["diversity" "values"]}
+    (:sections (company/get-company r/slug)) => {:company ["help" "diversity" "values"]
+                                                 :progress ["update" "team"]
+                                                 :financial ["finances"]}
 
       (fact "a section can be removed from the progress category"
         (let [new-set {:progress ["update" "finances" "help"]

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -318,7 +318,27 @@
           (:placeholder db-highlights) => true
           db-highlights => (contains placeholder)))
 
-        (future-fact "that used to exist"))
+      (future-fact "that used to exist"
+        (let [new-sections {:progress [] :company [] :financial []}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+              body (mock/body-from-response response)
+              db-company (company/get-company r/slug)]
+          (:status response) => 200
+          (:sections body) => new-sections
+          ; verify update is not in the response
+          (:update body) => nil
+          ; verify update not in the DB
+          (:update db-company) => nil)
+        (let [new-sections {:progress ["update"] :company [] :financial []}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+              body (mock/body-from-response response)
+              db-company (company/get-company r/slug)]
+          (:status response) => 200
+          (:sections body) => new-sections
+          ; verify update is not in the response
+          (:update body) => (contains r/text-section-1)
+          ; verify update not in the DB
+          (:update db-company) => (contains r/text-section-1))))
 
     (future-fact "with section content")
 

--- a/test/open_company/integration/section/section_revision.clj
+++ b/test/open_company/integration/section/section_revision.clj
@@ -294,7 +294,7 @@
   (facts "about updating a placeholder section"
 
     (facts "with PUT"
-      (with-state-changes [(before :facts (c/create-company! (c/add-placeholder-sections (c/->company r/buffer r/coyote))))
+      (with-state-changes [(before :facts (c/create-company! (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
                            (after :facts (c/delete-company (:slug r/buffer)))]
         (fact "update existing revision title"
           (let [updated  (assoc r/text-section-1 :title "New Title")
@@ -307,7 +307,7 @@
             (:placeholder body) => falsey))))
 
     (facts "with PATCH"
-      (with-state-changes [(before :facts (c/create-company! (c/add-placeholder-sections (c/->company r/buffer r/coyote))))
+      (with-state-changes [(before :facts (c/create-company! (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
                            (after :facts (c/delete-company (:slug r/buffer)))]
         (fact "update existing revision title"
           (let [updated  {:title "New Title"}

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -42,18 +42,17 @@
         (= created-at (:created-at retrieved-company)) => true
         (= updated-at (:updated-at retrieved-company)) => true))
 
+    (facts "it adds timestamps to notes"
+      (let [co (c/->company (assoc r/open :finances r/finances-notes-section-1) r/coyote)
+            company (c/create-company! co)
+            from-db (c/get-company (:slug r/open))]
+        (get-in from-db [:updated-at]) => (:updated-at company)
+        (get-in from-db [:finances :notes :updated-at]) => (:updated-at company)))
+
+    (fact "it returns the pre-defined categories"
+      (:categories (c/create-company! (c/->company r/open r/coyote))) => (contains common/category-names))
+
     (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
-      (facts "it adds timestamps to notes"
-        (let [w-note  (-> r/open (add-section :growth) (assoc-in [:growth :notes :body] "A Note"))
-              co      (c/->company w-note r/coyote)
-              company (c/create-company! co)
-              from-db (c/get-company (:slug r/open))]
-          (get-in from-db [:updated-at]) => (:updated-at company)
-          (get-in from-db [:growth :notes :updated-at]) => (:updated-at company)))
-
-      (fact "it returns the pre-defined categories"
-        (:categories (c/create-company! (c/->company r/open r/coyote))) => (contains common/category-names))
-
       (facts "it returns the sections in the company in the pre-defined order"
         (:sections (c/create-company! (c/->company r/open r/coyote))) => {:progress [] :financial [] :company []}
         (c/delete-company r/slug)

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -67,4 +67,4 @@
                                      (add-section :mission) (add-section :press) (add-section :help)
                                      (add-section :challenges) (add-section :diversity) (add-section :update))
                                  r/coyote)))
-        => {:progress [:update :challenges :press :help] :financial [] :company [:diversity :mission]}))))
+        => {:progress [:update :challenges :press] :financial [] :company [:mission :diversity :help]}))))

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -50,7 +50,7 @@
         (get-in from-db [:finances :notes :updated-at]) => (:updated-at company)))
 
     (fact "it returns the pre-defined categories"
-      (:categories (c/create-company! (c/->company r/open r/coyote))) => (contains common/category-names))
+      (:categories (c/create-company! (c/->company r/open r/coyote))) => common/category-names)
 
     (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
       (facts "it returns the sections in the company in the pre-defined order"

--- a/test/open_company/unit/resources/company/company_manipulate.clj
+++ b/test/open_company/unit/resources/company/company_manipulate.clj
@@ -22,7 +22,7 @@
     (fact "with missing placeholder sections"
       (let [company (c/get-company r/slug)
             missing-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
-            fixed-company (c/add-placeholder-sections (merge company missing-sections))]
+            fixed-company (c/add-placeholder-sections (merge company missing-sections))] ; this is what's tested
         (:highlights fixed-company) => (-> (common/section-by-name "highlights")
                                           (assoc :placeholder true)
                                           (dissoc :core))
@@ -31,6 +31,30 @@
                                           (dissoc :core))
         (:ownership fixed-company) => (-> (common/section-by-name "ownership")
                                           (assoc :placeholder true)
+                                          (dissoc :core))))
+
+    (future-fact "with partially specified placeholder sections"
+      (let [company (c/get-company r/slug)
+            updated-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+            updated-content (-> updated-sections
+                              (assoc :highlights {:body "body a"})
+                              (assoc :help {:title "title b" :body "body b"})
+                              (assoc :ownership {:title "title c" :headline "headline c" :body "body c"}))
+            fixed-company (c/merge-company company updated-content)] ; this is what's tested
+        (:highlights fixed-company) => (-> (common/section-by-name "highlights")
+                                          (assoc :placeholder false)
+                                          (assoc :body "body a")
+                                          (dissoc :core))
+        (:help fixed-company) => (-> (common/section-by-name "help")
+                                          (assoc :placeholder false)
+                                          (assoc :title "title b")
+                                          (assoc :body "body b")
+                                          (dissoc :core))
+        (:ownership fixed-company) => (-> (common/section-by-name "ownership")
+                                          (assoc :placeholder false)
+                                          (assoc :title "title c")
+                                          (assoc :headline "headline c")
+                                          (assoc :body "body c")
                                           (dissoc :core))))
 
     (fact "with missing prior sections"
@@ -51,7 +75,9 @@
       ; velify missing prior sections comes back
       (let [company (c/get-company r/slug)
             missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
-            fixed-company (c/add-prior-sections (merge company missing-sections))]
+            fixed-company (c/add-prior-sections (merge company missing-sections))] ; this is what's tested
         (:update fixed-company) => (contains r/text-section-1)
         (:values fixed-company) => (contains r/text-section-2)
-        (:finances fixed-company) => nil)))) ; and that this one doesn't come back
+        (:finances fixed-company) => nil)) ; and that this one doesn't come back
+
+    (future-fact "with partially specified prior sections")))

--- a/test/open_company/unit/resources/company/company_manipulate.clj
+++ b/test/open_company/unit/resources/company/company_manipulate.clj
@@ -1,0 +1,57 @@
+(ns open-company.unit.resources.company.company-manipulate
+  (:require [midje.sweet :refer :all]
+            [open-company.lib.resources :as r]
+            [open-company.lib.db :as db]
+            [open-company.resources.common :as common]
+            [open-company.resources.company :as c]
+            [open-company.resources.section :as s]))
+
+;; ----- Startup -----
+
+(db/test-startup)
+
+;; ----- Tests -----
+
+(with-state-changes [(before :facts (do
+                                      (c/delete-all-companies!)
+                                      (c/create-company! (c/->company r/open r/coyote))))
+                     (after :facts (c/delete-all-companies!))]
+
+  (facts "about fixing up companies"
+
+    (fact "with missing placeholder sections"
+      (let [company (c/get-company r/slug)
+            missing-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+            fixed-company (c/add-placeholder-sections (merge company missing-sections))]
+        (:highlights fixed-company) => (-> (common/section-by-name "highlights")
+                                          (assoc :placeholder true)
+                                          (dissoc :core))
+        (:help fixed-company) => (-> (common/section-by-name "help")
+                                          (assoc :placeholder true)
+                                          (dissoc :core))
+        (:ownership fixed-company) => (-> (common/section-by-name "ownership")
+                                          (assoc :placeholder true)
+                                          (dissoc :core))))
+
+    (fact "with missing prior sections"
+      ; add the sections to be priors
+      (s/put-section r/slug :update r/text-section-1 r/coyote)
+      (s/put-section r/slug :values r/text-section-2 r/coyote)
+      (s/put-section r/slug :finances r/finances-section-1 r/coyote)
+      ; remove the sections
+      (let [company (c/get-company r/slug)
+            updated-company (-> company 
+                              (assoc :sections {:sections {:progress [] :company [] :financial []}})
+                              (dissoc :update))]
+        (c/update-company r/slug updated-company))
+      ; verify the sections are gone
+      (:update (c/get-company r/slug)) => nil
+      (:values (c/get-company r/slug)) => nil
+      (:finances (c/get-company r/slug)) => nil
+      ; velify missing prior sections comes back
+      (let [company (c/get-company r/slug)
+            missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
+            fixed-company (c/add-prior-sections (merge company missing-sections))]
+        (:update fixed-company) => (contains r/text-section-1)
+        (:values fixed-company) => (contains r/text-section-2)
+        (:finances fixed-company) => nil)))) ; and that this one doesn't come back


### PR DESCRIPTION
Trello: https://trello.com/c/AWy33aAt

This PR fixes a hodgepodge of minor API issues:

* Defaults all section headlines to blanks
* Makes image and description read only properties of sections
* Remove PUT from company
* Makes PATCHed sections w/ no content get created as placeholders
* Disallow PATCHing made up sections into company
* normalize s/ as namespace alias for string and schema/ for prismatic schema
* Update icon set (also move it to S3 for easier updating w/o code changes)
* Ensures HATEOAS modify links are only present on individual section retrieval when they should be
* Ensures all the usage documented in the README works

To test:

* Look most closely at the test updates in the code changes. Ensure the tests are passing
* Observe the current new topic creation behavior in the client UI, this is enabled by these changes, does it seem good?
* Remove an existing topic that has some content, save it, then add the topic back, do you get the old content? This is enabled by these changes.
* Retrieve a section anonymously using cURL: `curl -i http://localhost:3000/companies/buffer/update` No update links anymore?
* Retrieve a section authorized, but back in time (with as-of). Easiest way to do this is to use the web UI on Buffer, it proactively caches the prior section revisions to the most recent. Look at the responses to those section retrievals with as-of in developer tools. No update links?
* Run through all the suggested code in the API README (start w/ a clean database). Does every line work now?

NOTE: The API is still incomplete as it relates to PATCHing sections. Right now, new sections can be PATCHed in blank (and they'll be placeholders, or the prior existing section), but they can't be PATCHed in with partial content (the rest of the content should come from the placeholder or prior section). There are some future-fact tests for this capability, but it doesn't exist yet. Primary reason being, I think we need to simplify the data model a bit and remove the sections being duplicated in the company document. It's just too complicated. No point implementing this full desired API, since our UI doesn't need it right now,  until we change that.