### PR TITLE
Componentize

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,114 +204,91 @@ Then enter these commands one-by-one, noting the output:
 })
 
 
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (company/create-company!
-   conn
-   (company/->company {:name "Blank Inc."
-                       :description "We're busy ideating."
-                       :currency "GBP"}
-                      author)))
+(company/create-company!
+ user/conn
+ (company/->company {:name "Blank Inc."
+                                            :slug "blank-inc"
+                                            :description "We're busy ideating."
+                                            :currency "GBP"}
+                                           author))
 
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (company/create-company!
-   conn
-   (company/->company {:name "OpenCompany"
-                       :description "Startup Transparency Made Simple"
-                       :logo "https://open-company-assets.s3.amazonaws.com/oc-logo.png"
-                       :slug "open"
-                       :home-page "https://opencompany.com/"
-                       :currency "USD"
-                       :finances {:title "Finances" :data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]}}
-                      author)))
+(company/create-company!
+ user/conn
+ (company/->company {:name "OpenCompany"
+                     :description "Startup Transparency Made Simple"
+                     :logo "https://open-company-assets.s3.amazonaws.com/oc-logo.png"
+                     :slug "open"
+                     :home-page "https://opencompany.com/"
+                     :currency "USD"
+                     :finances {:title "Finances" :data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]}}
+                    author))
 
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (company/create-company!
-   conn
-   (company/->company {:name "Buffer"
-                       :currency "USD"
-                       :description "A better way to share on social media."
-                       :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"
-                       :home-page "https://buffer.com/"
-                       :update {:title "Founder's Update"
-                                :headline "Buffer in October."
-                                :body "October was an unusual month for us, numbers-wise, as a result of us moving from 7-day to 30- day trials of Buffer for Business."}
-                       :finances {:title "Finances"
-                                  :data [{:period "2015-08" :cash 1182329 :revenue 1215 :costs 28019}
-                                         {:period "2015-09" :cash 1209133 :revenue 977 :costs 27155}]
-                                  :notes {:body "Good stuff! Revenue is up."}}}
-                      author)))
+(company/create-company!
+ user/conn
+ (company/->company {:name "Buffer"
+                     :currency "USD"
+                     :description "A better way to share on social media."
+                     :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"
+                     :home-page "https://buffer.com/"
+                     :update {:title "Founder's Update"
+                              :headline "Buffer in October."
+                              :body "October was an unusual month for us, numbers-wise, as a result of us moving from 7-day to 30- day trials of Buffer for Business."}
+                     :finances {:title "Finances"
+                                :data [{:period "2015-08" :cash 1182329 :revenue 1215 :costs 28019}
+                                       {:period "2015-09" :cash 1209133 :revenue 977 :costs 27155}]
+                                :notes {:body "Good stuff! Revenue is up."}}}
+                    author))
 
 ;; list companies
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (company/list-companies conn))
+(company/list-companies user/conn)
 
 ;; get a company
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (aprint (company/get-company conn "blank-inc")))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (aprint (company/get-company conn "open")))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (aprint (company/get-company conn "buffer")))
+(aprint (company/get-company user/conn "blank-inc"))
+(aprint (company/get-company user/conn "open"))
+(aprint (company/get-company user/conn "buffer"))
 
 ;; create/update a section
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]} author))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-                                                          {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
-                                                   :notes {:body "we got our first customer! revenue ftw!"}} author))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
-                                                          {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-                                                          {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
-  :notes {:body "we got our first customer! revenue ftw!"}} author))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
-                                                          {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-                                                          {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}
-                                                          {:period "2015-11" :cash 51125 :revenue 50 :costs 7912}]
-                                                   :notes {:body "we got our second customer! more revenue ftw!"}} author))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (aprint (company/get-company conn "blank-inc")))
+(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]} author)
+(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                             {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
+                                                      :notes {:body "we got our first customer! revenue ftw!"}} author)
+(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
+                                                             {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                             {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
+                                                      :notes {:body "we got our first customer! revenue ftw!"}} author)
+(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
+                                                             {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                             {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}
+                                                             {:period "2015-11" :cash 51125 :revenue 50 :costs 7912}]
+                                                      :notes {:body "we got our second customer! more revenue ftw!"}} author)
+(aprint (company/get-company user/conn "blank-inc"))
 
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/put-section conn "buffer" :update {:headline "it's all meh."} author)
-  (aprint (company/get-company conn "buffer")))
+(section/put-section user/conn "buffer" :update {:headline "it's all meh."} author)
+(aprint (company/get-company user/conn "buffer"))
 
 ;; get a section
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (aprint (section/get-section conn "blank-inc" :finances)))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (aprint (section/get-section conn "buffer" :update)))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (aprint (section/get-section conn "buffer" :finances)))
+(aprint (section/get-section user/conn "blank-inc" :finances))
+(aprint (section/get-section user/conn "buffer" :update))
+(aprint (section/get-section user/conn "buffer" :finances))
 
 ;; list revisions
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/list-revisions conn "blank-inc" :finances))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/list-revisions conn "buffer" :update))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/list-revisions conn "buffer" :finances))
+(section/list-revisions user/conn "blank-inc" :finances)
+(section/list-revisions user/conn "buffer" :update)
+(section/list-revisions user/conn "buffer" :finances)
 ;; note: due to revision collapsing by same author in a short period, there won't as many revisions as you
 ;; might think. the introduction of a new note by the same author in finances section of blank-inc causes
 ;; a new revision, but the rest of the updates above are collapsed into one revision.
 
 ;; get revisions
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/get-revisions conn "blank-inc" :finances))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/get-revisions conn "buffer" :update))
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (section/get-revisions conn "buffer" :finances))
+(section/get-revisions user/conn "blank-inc" :finances)
+(section/get-revisions user/conn "buffer" :update)
+(section/get-revisions user/conn "buffer" :finances)
 
 ;; delete a company
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (company/delete-company conn "blank-inc"))
+(company/delete-company user/conn "blank-inc")
 
 ;; cleanup
-(pool/with-pool [conn (-> user/system :db-pool :pool)]
-  (company/delete-all-companies! conn))
+(company/delete-all-companies! user/conn)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -178,14 +178,8 @@ lein repl
 Then enter these commands one-by-one, noting the output:
 
 ```clojure
-(require 'user)
-(require '[open-company.db.init :as db])
-(require '[open-company.db.pool :as pool])
-(require '[open-company.resources.company :as company])
-(require '[open-company.resources.section :as section])
-
-;; start development system
-(user/go)
+;; start the development system
+(go) ; NOTE: if you are already running the API externally to the REPL, use `(go 3737)` to change the port
 
 ;; create db and tables and indexes
 (db/init)
@@ -205,90 +199,90 @@ Then enter these commands one-by-one, noting the output:
 
 
 (company/create-company!
- user/conn
- (company/->company {:name "Blank Inc."
-                                            :slug "blank-inc"
-                                            :description "We're busy ideating."
-                                            :currency "GBP"}
-                                           author))
-
-(company/create-company!
- user/conn
- (company/->company {:name "OpenCompany"
-                     :description "Startup Transparency Made Simple"
-                     :logo "https://open-company-assets.s3.amazonaws.com/oc-logo.png"
-                     :slug "open"
-                     :home-page "https://opencompany.com/"
-                     :currency "USD"
-                     :finances {:title "Finances" :data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]}}
+  conn
+  (company/->company {:name "Blank Inc."
+                      :slug "blank-inc"
+                      :description "We're busy ideating."
+                      :currency "GBP"}
                     author))
 
 (company/create-company!
- user/conn
- (company/->company {:name "Buffer"
-                     :currency "USD"
-                     :description "A better way to share on social media."
-                     :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"
-                     :home-page "https://buffer.com/"
-                     :update {:title "Founder's Update"
-                              :headline "Buffer in October."
-                              :body "October was an unusual month for us, numbers-wise, as a result of us moving from 7-day to 30- day trials of Buffer for Business."}
-                     :finances {:title "Finances"
-                                :data [{:period "2015-08" :cash 1182329 :revenue 1215 :costs 28019}
-                                       {:period "2015-09" :cash 1209133 :revenue 977 :costs 27155}]
-                                :notes {:body "Good stuff! Revenue is up."}}}
+  conn
+  (company/->company {:name "OpenCompany"
+                      :description "Startup Transparency Made Simple"
+                      :logo "https://open-company-assets.s3.amazonaws.com/oc-logo.png"
+                      :slug "open"
+                      :home-page "https://opencompany.com/"
+                      :currency "USD"
+                      :finances {:title "Finances" :data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]}}
+                    author))
+
+(company/create-company!
+  conn
+  (company/->company {:name "Buffer"
+                      :currency "USD"
+                      :description "A better way to share on social media."
+                      :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"
+                      :home-page "https://buffer.com/"
+                      :update {:title "Founder's Update"
+                               :headline "Buffer in October."
+                               :body "October was an unusual month for us, numbers-wise, as a result of us moving from 7-day to 30- day trials of Buffer for Business."}
+                      :finances {:title "Finances"
+                                 :data [{:period "2015-08" :cash 1182329 :revenue 1215 :costs 28019}
+                                        {:period "2015-09" :cash 1209133 :revenue 977 :costs 27155}]
+                                 :notes {:body "Good stuff! Revenue is up."}}}
                     author))
 
 ;; list companies
-(company/list-companies user/conn)
+(company/list-companies conn)
 
 ;; get a company
-(aprint (company/get-company user/conn "blank-inc"))
-(aprint (company/get-company user/conn "open"))
-(aprint (company/get-company user/conn "buffer"))
+(aprint (company/get-company conn "blank-inc"))
+(aprint (company/get-company conn "open"))
+(aprint (company/get-company conn "buffer"))
 
 ;; create/update a section
-(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]} author)
-(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-                                                             {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
-                                                      :notes {:body "we got our first customer! revenue ftw!"}} author)
-(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
-                                                             {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-                                                             {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
-                                                      :notes {:body "we got our first customer! revenue ftw!"}} author)
-(section/put-section user/conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
-                                                             {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-                                                             {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}
-                                                             {:period "2015-11" :cash 51125 :revenue 50 :costs 7912}]
-                                                      :notes {:body "we got our second customer! more revenue ftw!"}} author)
-(aprint (company/get-company user/conn "blank-inc"))
+(section/put-section conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]} author)
+(section/put-section conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                        {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
+                                                 :notes {:body "we got our first customer! revenue ftw!"}} author)
+(section/put-section conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
+                                                        {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                        {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
+                                                 :notes {:body "we got our first customer! revenue ftw!"}} author)
+(section/put-section conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
+                                                        {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                        {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}
+                                                        {:period "2015-11" :cash 51125 :revenue 50 :costs 7912}]
+                                                 :notes {:body "we got our second customer! more revenue ftw!"}} author)
+(aprint (company/get-company conn "blank-inc"))
 
-(section/put-section user/conn "buffer" :update {:headline "it's all meh."} author)
-(aprint (company/get-company user/conn "buffer"))
+(section/put-section conn "buffer" :update {:headline "it's all meh."} author)
+(aprint (company/get-company conn "buffer"))
 
 ;; get a section
-(aprint (section/get-section user/conn "blank-inc" :finances))
-(aprint (section/get-section user/conn "buffer" :update))
-(aprint (section/get-section user/conn "buffer" :finances))
+(aprint (section/get-section conn "blank-inc" :finances))
+(aprint (section/get-section conn "buffer" :update))
+(aprint (section/get-section conn "buffer" :finances))
 
 ;; list revisions
-(section/list-revisions user/conn "blank-inc" :finances)
-(section/list-revisions user/conn "buffer" :update)
-(section/list-revisions user/conn "buffer" :finances)
+(section/list-revisions conn "blank-inc" :finances)
+(section/list-revisions conn "buffer" :update)
+(section/list-revisions conn "buffer" :finances)
 ;; note: due to revision collapsing by same author in a short period, there won't as many revisions as you
 ;; might think. the introduction of a new note by the same author in finances section of blank-inc causes
 ;; a new revision, but the rest of the updates above are collapsed into one revision.
 
 ;; get revisions
-(section/get-revisions user/conn "blank-inc" :finances)
-(section/get-revisions user/conn "buffer" :update)
-(section/get-revisions user/conn "buffer" :finances)
+(section/get-revisions conn "blank-inc" :finances)
+(section/get-revisions conn "buffer" :update)
+(section/get-revisions conn "buffer" :finances)
 
 ;; delete a company
-(company/delete-company user/conn "blank-inc")
+(company/delete-company conn "blank-inc")
 
 ;; cleanup
-(company/delete-all-companies! user/conn)
+(company/delete-all-companies! conn)
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -178,14 +178,19 @@ lein repl
 Then enter these commands one-by-one, noting the output:
 
 ```clojure
+(require 'user)
 (require '[open-company.db.init :as db])
+(require '[open-company.db.pool :as pool])
 (require '[open-company.resources.company :as company])
 (require '[open-company.resources.section :as section])
 
-;; Create DB and tables and indexes
+;; start development system
+(user/go)
+
+;; create db and tables and indexes
 (db/init)
 
-;; Create some companies
+;; create some companies
 
 (def author {
   :user-id "slack:123456"
@@ -198,91 +203,115 @@ Then enter these commands one-by-one, noting the output:
   :org-id "slack:98765"
 })
 
-(company/create-company!
- (company/->company {:name "Blank Inc."
-                     :description "We're busy ideating."
-                     :currency "GBP"}
-                    author))
 
-(company/create-company!
- (company/->company {:name "OpenCompany"
-                     :description "Startup Transparency Made Simple"
-                     :logo "https://open-company-assets.s3.amazonaws.com/oc-logo.png"
-                     :slug "open"
-                     :home-page "https://opencompany.com/"
-                     :currency "USD"
-                     :finances {:title "Finances"
-                     :data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]}}
-                     author))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (company/create-company!
+   conn
+   (company/->company {:name "Blank Inc."
+                       :description "We're busy ideating."
+                       :currency "GBP"}
+                      author)))
 
-(company/create-company!
- (company/->company {:name "Buffer"
-                     :currency "USD"
-                     :description "A better way to share on social media."
-                     :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"
-                     :home-page "https://buffer.com/"
-                     :update {:title "Founder's Update"
-                              :headline "Buffer in October."
-                              :body "October was an unusual month for us, numbers-wise, as a result of us moving from 7-day to 30- day trials of Buffer for Business."}
-                     :finances {:title "Finances"
-                                :data [{:period "2015-08" :cash 1182329 :revenue 1215 :costs 28019}
-                                       {:period "2015-09" :cash 1209133 :revenue 977 :costs 27155}]
-                                :notes {:body "Good stuff! Revenue is up."}}}
-                    author))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (company/create-company!
+   conn
+   (company/->company {:name "OpenCompany"
+                       :description "Startup Transparency Made Simple"
+                       :logo "https://open-company-assets.s3.amazonaws.com/oc-logo.png"
+                       :slug "open"
+                       :home-page "https://opencompany.com/"
+                       :currency "USD"
+                       :finances {:title "Finances" :data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]}}
+                      author)))
 
-;; List companies
-(company/list-companies)
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (company/create-company!
+   conn
+   (company/->company {:name "Buffer"
+                       :currency "USD"
+                       :description "A better way to share on social media."
+                       :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"
+                       :home-page "https://buffer.com/"
+                       :update {:title "Founder's Update"
+                                :headline "Buffer in October."
+                                :body "October was an unusual month for us, numbers-wise, as a result of us moving from 7-day to 30- day trials of Buffer for Business."}
+                       :finances {:title "Finances"
+                                  :data [{:period "2015-08" :cash 1182329 :revenue 1215 :costs 28019}
+                                         {:period "2015-09" :cash 1209133 :revenue 977 :costs 27155}]
+                                  :notes {:body "Good stuff! Revenue is up."}}}
+                      author)))
 
-;; Get a company
-(aprint (company/get-company "blank-inc"))
-(aprint (company/get-company "open"))
-(aprint (company/get-company "buffer"))
+;; list companies
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (company/list-companies conn))
 
-;; Create/update a section
-(section/put-section "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]} author)
-(section/put-section "blank-inc" :finances {:data [
-  {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-  {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
-  :notes {:body "We got our first customer! Revenue FTW!"}} author)
-(section/put-section "blank-inc" :finances {:data [
-  {:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
-  {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-  {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
-  :notes {:body "We got our first customer! Revenue FTW!"}} author)
-(section/put-section "blank-inc" :finances {:data [
-  {:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
-  {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
-  {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}
-  {:period "2015-11" :cash 51125 :revenue 50 :costs 7912}]
-  :notes {:body "We got our second customer! More revenue FTW!"}} author)
-(aprint (company/get-company "blank-inc"))
+;; get a company
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (aprint (company/get-company conn "blank-inc")))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (aprint (company/get-company conn "open")))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (aprint (company/get-company conn "buffer")))
 
-(section/put-section "buffer" :update {:headline "It's all meh."} author)
-(aprint (company/get-company "buffer"))
+;; create/update a section
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}]} author))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                          {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
+                                                   :notes {:body "we got our first customer! revenue ftw!"}} author))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
+                                                          {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                          {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}]
+  :notes {:body "we got our first customer! revenue ftw!"}} author))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/put-section conn "blank-inc" :finances {:data [{:period "2015-08" :cash 75000 :revenue 0 :costs 6778}
+                                                          {:period "2015-09" :cash 66981 :revenue 0 :costs 8019}
+                                                          {:period "2015-10" :cash 58987 :revenue 25 :costs 7867}
+                                                          {:period "2015-11" :cash 51125 :revenue 50 :costs 7912}]
+                                                   :notes {:body "we got our second customer! more revenue ftw!"}} author))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (aprint (company/get-company conn "blank-inc")))
 
-;; Get a section
-(aprint (section/get-section "blank-inc" :finances))
-(aprint (section/get-section "buffer" :update))
-(aprint (section/get-section "buffer" :finances))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/put-section conn "buffer" :update {:headline "it's all meh."} author)
+  (aprint (company/get-company conn "buffer")))
 
-;; List revisions
-(section/list-revisions "blank-inc" :finances)
-(section/list-revisions "buffer" :update)
-(section/list-revisions "buffer" :finances)
-;; Note: due to revision collapsing by same author in a short period, there won't as many revisions as you
-;; might think. The introduction of a new note by the same author in finances section of blank-inc causes
+;; get a section
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (aprint (section/get-section conn "blank-inc" :finances)))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (aprint (section/get-section conn "buffer" :update)))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (aprint (section/get-section conn "buffer" :finances)))
+
+;; list revisions
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/list-revisions conn "blank-inc" :finances))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/list-revisions conn "buffer" :update))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/list-revisions conn "buffer" :finances))
+;; note: due to revision collapsing by same author in a short period, there won't as many revisions as you
+;; might think. the introduction of a new note by the same author in finances section of blank-inc causes
 ;; a new revision, but the rest of the updates above are collapsed into one revision.
 
-;; Get revisions
-(section/get-revisions "blank-inc" :finances)
-(section/get-revisions "buffer" :update)
-(section/get-revisions "buffer" :finances)
+;; get revisions
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/get-revisions conn "blank-inc" :finances))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/get-revisions conn "buffer" :update))
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (section/get-revisions conn "buffer" :finances))
 
-;; Delete a company
-(company/delete-company "blank-inc")
+;; delete a company
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (company/delete-company conn "blank-inc"))
 
-;; Cleanup
-(company/delete-all-companies!)
+;; cleanup
+(pool/with-pool [conn (-> user/system :db-pool :pool)]
+  (company/delete-all-companies! conn))
 ```
 
 

--- a/project.clj
+++ b/project.clj
@@ -92,7 +92,21 @@
                  '[clojure.stacktrace :refer (print-stack-trace)]
                  '[clj-time.core :as t]
                  '[clj-time.format :as f]
-                 '[clojure.string :as s])
+                 '[clojure.string :as s]
+                 '[rethinkdb.query :as r]
+                 '[schema.core :as schema]
+                 '[cheshire.core :as json]
+                 '[ring.mock.request :refer (request body content-type header)]
+                 '[open-company.lib.rest-api-mock :refer (api-request)]
+                 '[open-company.app :refer (app)]
+                 '[open-company.config :as c]
+                 '[open-company.db.init :as db]
+                 '[open-company.lib.slugify :as slug]
+                 '[open-company.resources.common :as common]
+                 '[open-company.resources.company :as company]
+                 '[open-company.resources.section :as section]
+                 '[open-company.representations.company :as company-rep]
+                 '[open-company.representations.section :as section-rep])
       ]
     }]
 
@@ -104,6 +118,14 @@
         :hot-reload "false"
       }
     }
+  }
+
+  :repl-options {
+    :welcome (println (str "\n" (slurp (clojure.java.io/resource "open_company/assets/ascii_art.txt")) "\n"
+                      "OpenCompany REPL\n"
+                      "Database: " open-company.config/db-name "\n"
+                      "Ready to do your bidding... I suggest (go) or (go <port>) as your first command\n"))
+    :init-ns user
   }
 
   :aliases {

--- a/project.clj
+++ b/project.clj
@@ -124,7 +124,7 @@
 
   :eastwood {
     ;; Disable some linters that are enabled by default
-    :exclude-linters [:wrong-arity]
+    :exclude-linters [:constant-test :wrong-arity]
     ;; Enable some linters that are disabled by default
     :add-linters [:unused-namespaces :unused-private-vars] ; :unused-locals]
 

--- a/project.clj
+++ b/project.clj
@@ -33,6 +33,7 @@
     [org.clojure/tools.cli "0.3.3"] ; Command-line parsing https://github.com/clojure/tools.cli
     [clj-jwt "0.1.1"] ; Library for JSON Web Token (JWT) https://github.com/liquidz/clj-jwt
     [medley "0.7.3"] ; Utility functions https://github.com/weavejester/medley
+    [com.stuartsierra/component "0.3.1"] ; Component Lifecycle
  ]
 
   ;; Production plugins

--- a/src/open_company/api/common.clj
+++ b/src/open_company/api/common.clj
@@ -137,9 +137,9 @@
 
 (defn allow-org-members
   "Allow only if there is no company, or the user's JWToken indicates membership in the company's org."
-  [company-slug ctx]
+  [conn company-slug ctx]
   (let [user    (:user ctx)
-        company (company/get-company company-slug)]
+        company (company/get-company conn company-slug)]
     (cond
       (and user company) (authorized-to-company? {:company company :user user})
       (nil? company)     true

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -78,8 +78,8 @@
     [true {}])) ; it will fail later on :exists?
 
 (defn processable-post-req? [conn {:keys [user data]}]
-  (let [company (company/->company data user (find-slug conn data))
-        invalid? (schema/check common-res/Company company)
+  (let [company     (company/->company data user (find-slug conn data))
+        invalid?    (schema/check common-res/Company company)
         slug-taken? (not (company/slug-available? conn (:slug company)))]
     (cond
       invalid? [false {:reason invalid?}]

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -149,7 +149,7 @@
 
   :post! (fn [ctx] {:company (pool/with-pool [conn db-pool]
                                (->> (company/->company (:data ctx) (:user ctx) (find-slug conn (:data ctx)))
-                                    (company/add-placeholder-sections)
+                                    (company/add-core-placeholder-sections)
                                     (company/create-company! conn)))})
 
   :handle-ok (fn [ctx] (company-rep/render-company-list (:companies ctx)))

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -94,7 +94,7 @@
   common/open-company-anonymous-resource ; verify validity of JWToken if it's provided, but it's not required
 
   :available-media-types [company-rep/media-type]
-  :exists? (fn [_] (pool/with-pool [conn db-pool] (get-company conn slug ctx)))
+  :exists? (fn [ctx] (pool/with-pool [conn db-pool] (get-company conn slug ctx)))
   :known-content-type? (fn [ctx] (common/known-content-type? ctx company-rep/media-type))
 
   :allowed-methods [:options :get :patch :delete]
@@ -107,7 +107,7 @@
   :processable? (by-method {
     :options true
     :get true
-    :patch (fn [ctx] (processable-patch-req? slug ctx))})
+    :patch (fn [ctx] (pool/with-pool [conn db-pool] (processable-patch-req? conn slug ctx)))})
 
   ;; Handlers
   :handle-ok (by-method {
@@ -177,7 +177,7 @@
                       (common/missing-response)))
 
   ;; Get a list of sections
-  :exists? (fn [_] (pool/with-pool [conn db-pool] (get-company conn slug ctx)))
+  :exists? (fn [ctx] (pool/with-pool [conn db-pool] (get-company conn slug ctx)))
   :handle-ok (fn [_] sections))
 
 ;; ----- Routes -----

--- a/src/open_company/api/entry.clj
+++ b/src/open_company/api/entry.clj
@@ -42,5 +42,11 @@
 ;; ----- Routes -----
 
 (defroutes entry-routes
+  ;; (routes ...)
   (OPTIONS "/" [] (entry-point))
   (GET "/" [] (entry-point)))
+
+(defn entry-routes [{:keys [db-pool]}]
+  (routes
+   (OPTIONS "/" [] (entry-point))
+   (GET "/" [] (entry-point))))

--- a/src/open_company/api/sections.clj
+++ b/src/open_company/api/sections.clj
@@ -2,6 +2,7 @@
   (:require [if-let.core :refer (if-let*)]
             [compojure.core :refer (routes ANY)]
             [liberator.core :refer (defresource by-method)]
+            [open-company.db.pool :as pool]
             [open-company.api.common :as common]
             [open-company.resources.common :as common-res]
             [open-company.resources.company :as company-res]
@@ -11,9 +12,9 @@
 
 ;; ----- Responses -----
 
-(defn- section-location-response [section]
+(defn- section-location-response [conn section]
   (common/location-response ["companies" (:company-slug section) (:section-name section)]
-    (section-rep/render-section section) section-rep/media-type))
+    (section-rep/render-section conn section) section-rep/media-type))
 
 (defn- unprocessable-reason [reason]
   (case reason
@@ -21,9 +22,9 @@
     :bad-section-name (common/missing-response)
     (common/unprocessable-entity-response "Not processable.")))
 
-(defn- options-for-section [company-slug section-name ctx]
-  (if-let* [company (company-res/get-company company-slug)
-            _section (section-res/get-section company-slug section-name)]
+(defn- options-for-section [conn company-slug section-name ctx]
+  (if-let* [company (company-res/get-company conn company-slug)
+            _section (section-res/get-section conn company-slug section-name)]
     (if (common/authorized-to-company? (assoc ctx :company company))
       (common/options-response [:options :get :put :patch])
       (common/options-response [:options :get]))
@@ -31,30 +32,34 @@
 
 ;; ----- Actions -----
 
-(defn- get-section [company-slug section-name as-of]
-  (let [section     (section-res/get-section company-slug section-name as-of)
-        placeholder (get (company-res/get-company company-slug) (keyword section-name))]
+(defn- get-section [conn company-slug section-name as-of]
+  (let [section     (section-res/get-section conn company-slug section-name as-of)
+        placeholder (get (company-res/get-company conn company-slug) (keyword section-name))]
     (when-let [s (or section placeholder)]
       {:section s})))
 
-(defn- put-section [company-slug section-name section author]
-  {:updated-section (section-res/put-section company-slug section-name section author)})
+(defn- put-section [conn company-slug section-name section author]
+  {:updated-section (section-res/put-section conn company-slug section-name section author)})
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
 
-(defresource section [company-slug section-name as-of]
+;; (pool/with-pool [conn (-> user/system :db-pool :pool)]
+;;   (get-section conn "buffer" "team" nil)
+;;   (company-res/get-company conn "buffer"))
+
+(defresource section [db-pool company-slug section-name as-of]
   common/open-company-anonymous-resource
 
   :allowed-methods [:options :get :put :patch]
   :available-media-types [section-rep/media-type]
-  :exists? (fn [_] (get-section company-slug section-name as-of))
+  :exists? (fn [_] (pool/with-pool [conn db-pool] (get-section conn company-slug section-name as-of)))
   :known-content-type? (fn [ctx] (common/known-content-type? ctx section-rep/media-type))
 
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
     :get (fn [ctx] (common/allow-anonymous ctx))
-    :put (fn [ctx] (common/allow-org-members company-slug ctx))
-    :patch (fn [ctx] (common/allow-org-members company-slug ctx))
+    :put (fn [ctx] (pool/with-pool [conn db-pool] (common/allow-org-members conn company-slug ctx)))
+    :patch (fn [ctx] (pool/with-pool [conn db-pool] (common/allow-org-members conn company-slug ctx)))
     :post false
     :delete false})
 
@@ -75,25 +80,27 @@
 
   ;; Handlers
   :handle-ok (by-method {
-    :get (fn [ctx] (section-rep/render-section (:section ctx)
-                                               (common/allow-org-members company-slug ctx)
-                                               (not (nil? as-of))))
-    :put (fn [ctx] (section-rep/render-section (:updated-section ctx)))
-    :patch (fn [ctx] (section-rep/render-section (:updated-section ctx)))})
+    :get (fn [ctx] (pool/with-pool [conn db-pool]
+                    (section-rep/render-section (:section ctx) (common/allow-org-members company-slug ctx) (not (nil? as-of)))))
+    :put (fn [ctx] (pool/with-pool [conn db-pool] (section-rep/render-section conn (:updated-section ctx))))
+    :patch (fn [ctx] (pool/with-pool [conn db-pool] (section-rep/render-section conn (:updated-section ctx))))})
   :handle-not-acceptable (fn [_] (common/only-accept 406 section-rep/media-type))
   :handle-unsupported-media-type (fn [_] (common/only-accept 415 section-rep/media-type))
   :handle-unprocessable-entity (fn [ctx] (unprocessable-reason (:reason ctx)))
-  :handle-options (fn [ctx] (options-for-section company-slug section-name ctx))
+  :handle-options (fn [ctx] (pool/with-pool [conn db-pool] (options-for-section conn company-slug section-name ctx)))
 
   ;; Create or update a section
   :new? (by-method {:put (fn [ctx] (not (:section ctx)))})
-  :put! (fn [ctx] (put-section company-slug section-name (:data ctx) (:user ctx)))
-  :patch! (fn [ctx] (put-section company-slug section-name (merge (:section ctx) (:data ctx)) (:user ctx)))
-  :handle-created (fn [ctx] (section-location-response (:updated-section ctx))))
+  :put! (fn [ctx] (pool/with-pool [conn db-pool] (put-section conn company-slug section-name (:data ctx) (:user ctx))))
+  :patch! (fn [ctx] (pool/with-pool [conn db-pool] (put-section conn company-slug section-name (merge (:section ctx) (:data ctx)) (:user ctx))))
+  :handle-created (fn [ctx] (pool/with-pool [conn db-pool] (section-location-response conn (:updated-section ctx)))))
 
 ;; ----- Routes -----
 
-(def section-routes
-  (apply routes
-    (map #(ANY (str "/companies/:company-slug/" %) [company-slug as-of]
-      (section company-slug % as-of)) (map name common-res/section-names))))
+(defn section-routes [sys]
+  (let [db-pool (-> sys :db-pool :pool)]
+    (apply routes
+      (map #(ANY (str "/companies/:company-slug/" %)
+                  [company-slug as-of]
+                  (section db-pool company-slug % as-of))
+          (map name common-res/section-names)))))

--- a/src/open_company/api/sections.clj
+++ b/src/open_company/api/sections.clj
@@ -81,7 +81,7 @@
   ;; Handlers
   :handle-ok (by-method {
     :get (fn [ctx] (pool/with-pool [conn db-pool]
-                    (section-rep/render-section (:section ctx) (common/allow-org-members company-slug ctx) (not (nil? as-of)))))
+                    (section-rep/render-section conn (:section ctx) (common/allow-org-members company-slug ctx) (not (nil? as-of)))))
     :put (fn [ctx] (pool/with-pool [conn db-pool] (section-rep/render-section conn (:updated-section ctx))))
     :patch (fn [ctx] (pool/with-pool [conn db-pool] (section-rep/render-section conn (:updated-section ctx))))})
   :handle-not-acceptable (fn [_] (common/only-accept 406 section-rep/media-type))

--- a/src/open_company/api/sections.clj
+++ b/src/open_company/api/sections.clj
@@ -47,19 +47,19 @@
 ;;   (get-section conn "buffer" "team" nil)
 ;;   (company-res/get-company conn "buffer"))
 
-(defresource section [db-pool company-slug section-name as-of]
+(defresource section [conn company-slug section-name as-of]
   common/open-company-anonymous-resource
 
   :allowed-methods [:options :get :put :patch]
   :available-media-types [section-rep/media-type]
-  :exists? (fn [_] (pool/with-pool [conn db-pool] (get-section conn company-slug section-name as-of)))
+  :exists? (fn [_] (get-section conn company-slug section-name as-of))
   :known-content-type? (fn [ctx] (common/known-content-type? ctx section-rep/media-type))
 
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
     :get (fn [ctx] (common/allow-anonymous ctx))
-    :put (fn [ctx] (pool/with-pool [conn db-pool] (common/allow-org-members conn company-slug ctx)))
-    :patch (fn [ctx] (pool/with-pool [conn db-pool] (common/allow-org-members conn company-slug ctx)))
+    :put (fn [ctx] (common/allow-org-members conn company-slug ctx))
+    :patch (fn [ctx] (common/allow-org-members conn company-slug ctx))
     :post false
     :delete false})
 
@@ -80,20 +80,19 @@
 
   ;; Handlers
   :handle-ok (by-method {
-    :get (fn [ctx] (pool/with-pool [conn db-pool]
-                    (section-rep/render-section conn (:section ctx) (common/allow-org-members company-slug ctx) (not (nil? as-of)))))
-    :put (fn [ctx] (pool/with-pool [conn db-pool] (section-rep/render-section conn (:updated-section ctx))))
-    :patch (fn [ctx] (pool/with-pool [conn db-pool] (section-rep/render-section conn (:updated-section ctx))))})
+    :get (fn [ctx] (section-rep/render-section conn (:section ctx) (common/allow-org-members company-slug ctx) (not (nil? as-of))))
+    :put (fn [ctx] (section-rep/render-section conn (:updated-section ctx)))
+    :patch (fn [ctx] (section-rep/render-section conn (:updated-section ctx)))})
   :handle-not-acceptable (fn [_] (common/only-accept 406 section-rep/media-type))
   :handle-unsupported-media-type (fn [_] (common/only-accept 415 section-rep/media-type))
   :handle-unprocessable-entity (fn [ctx] (unprocessable-reason (:reason ctx)))
-  :handle-options (fn [ctx] (pool/with-pool [conn db-pool] (options-for-section conn company-slug section-name ctx)))
+  :handle-options (fn [ctx] (options-for-section conn company-slug section-name ctx))
 
   ;; Create or update a section
   :new? (by-method {:put (fn [ctx] (not (:section ctx)))})
-  :put! (fn [ctx] (pool/with-pool [conn db-pool] (put-section conn company-slug section-name (:data ctx) (:user ctx))))
-  :patch! (fn [ctx] (pool/with-pool [conn db-pool] (put-section conn company-slug section-name (merge (:section ctx) (:data ctx)) (:user ctx))))
-  :handle-created (fn [ctx] (pool/with-pool [conn db-pool] (section-location-response conn (:updated-section ctx)))))
+  :put! (fn [ctx] (put-section conn company-slug section-name (:data ctx) (:user ctx)))
+  :patch! (fn [ctx] (put-section conn company-slug section-name (merge (:section ctx) (:data ctx)) (:user ctx)))
+  :handle-created (fn [ctx] (section-location-response conn (:updated-section ctx))))
 
 ;; ----- Routes -----
 
@@ -102,5 +101,5 @@
     (apply routes
       (map #(ANY (str "/companies/:company-slug/" %)
                   [company-slug as-of]
-                  (section db-pool company-slug % as-of))
+                  (pool/with-pool [conn db-pool] (section conn company-slug % as-of)))
           (map name common-res/section-names)))))

--- a/src/open_company/app.clj
+++ b/src/open_company/app.clj
@@ -14,15 +14,15 @@
     [com.stuartsierra.component :as component]
     [open-company.components :as components]
     [open-company.config :as c]
-    [open-company.api.entry :as entry]
-    [open-company.api.companies :as company]
-    [open-company.api.sections :as section]))
+    [open-company.api.entry :as entry-api]
+    [open-company.api.companies :as comp-api]
+    [open-company.api.sections :as sect-api]))
 
 (defn routes [sys]
   (compojure/routes
-   (entry/entry-routes sys)
-   (company/company-routes sys)
-   (section/section-routes sys)))
+   (entry-api/entry-routes sys)
+   (comp-api/company-routes sys)
+   (sect-api/section-routes sys)))
 
 (defn app [sys]
   (cond-> (routes sys)

--- a/src/open_company/components.clj
+++ b/src/open_company/components.clj
@@ -1,0 +1,41 @@
+(ns open-company.components
+  (:require [com.stuartsierra.component :as component]
+            [taoensso.timbre :as timbre]
+            [open-company.db.pool :as pool]
+            [org.httpkit.server :as httpkit]))
+
+(defrecord HttpKit [options handler server]
+  component/Lifecycle
+  (start [component]
+    (let [handler (get-in component [:handler :handler] handler)
+          server (httpkit/run-server handler options)]
+      (timbre/info "Starting HTTPKit server")
+      (assoc component :server server)))
+  (stop [component]
+    (when server
+      (server)
+      component)))
+
+(defrecord RethinkPool [size regenerate-interval pool]
+  component/Lifecycle
+  (start [component]
+    (timbre/info "Starting RethinkDB connection pool")
+    (let [pool (pool/fixed-pool pool/init-conn pool/close-conn
+                                {:size size :regenerate-interval 15})]
+      (assoc component :pool pool)))
+  (stop [component]
+    (when pool
+      (do 
+        (timbre/info "Stopping RethinkDB connection pool")
+        (pool/shutdown-pool! pool)
+        (dissoc component :pool))
+      component)))
+
+(defrecord Handler [handler-fn]
+  (start [component]
+    (assoc component :handler (handler-fn component)))
+  (stop [component]
+    (dissoc component :handler)))
+
+(def pool
+  (map->RethinkPool {:size 5 :regenerate-interval 10}))

--- a/src/open_company/components.clj
+++ b/src/open_company/components.clj
@@ -8,34 +8,46 @@
   component/Lifecycle
   (start [component]
     (let [handler (get-in component [:handler :handler] handler)
-          server (httpkit/run-server handler options)]
-      (timbre/info "Starting HTTPKit server")
+          server  (httpkit/run-server handler options)]
       (assoc component :server server)))
   (stop [component]
-    (when server
-      (server)
-      component)))
+    ;; (prn component)
+    (if-not server
+      component
+      (do
+        (server)
+        (dissoc component :server)))))
 
 (defrecord RethinkPool [size regenerate-interval pool]
   component/Lifecycle
   (start [component]
-    (timbre/info "Starting RethinkDB connection pool")
     (let [pool (pool/fixed-pool pool/init-conn pool/close-conn
                                 {:size size :regenerate-interval 15})]
       (assoc component :pool pool)))
   (stop [component]
-    (when pool
-      (do 
-        (timbre/info "Stopping RethinkDB connection pool")
+    (if pool
+      (do
         (pool/shutdown-pool! pool)
         (dissoc component :pool))
       component)))
 
 (defrecord Handler [handler-fn]
+  component/Lifecycle
   (start [component]
     (assoc component :handler (handler-fn component)))
   (stop [component]
     (dissoc component :handler)))
 
-(def pool
-  (map->RethinkPool {:size 5 :regenerate-interval 10}))
+;; (def pool
+;;   (map->RethinkPool {:size 5 :regenerate-interval 10}))
+
+(defn oc-system [opts]
+  (let [{:keys [host port handler-fn]} opts]
+    (component/system-map
+     :db-pool (map->RethinkPool {:size 5 :regenerate-interval 5})
+     :handler (component/using
+               (map->Handler {:handler-fn handler-fn})
+               [:db-pool])
+     :server  (component/using
+               (map->HttpKit {:options {:port port}})
+               [:handler]))))

--- a/src/open_company/components.clj
+++ b/src/open_company/components.clj
@@ -1,6 +1,5 @@
 (ns open-company.components
   (:require [com.stuartsierra.component :as component]
-            [taoensso.timbre :as timbre]
             [open-company.db.pool :as pool]
             [org.httpkit.server :as httpkit]))
 

--- a/src/open_company/db/pool.clj
+++ b/src/open_company/db/pool.clj
@@ -12,6 +12,9 @@
   []
   (apply r/connect config/db-options))
 
+(defn close-conn [conn]
+  (rethinkdb.core/close conn))
+
 ;; Taken from the wonderful aphyr's Riemann
 ;; https://github.com/riemann/riemann/blob/master/src/riemann/pool.clj
 

--- a/src/open_company/db/pool.clj
+++ b/src/open_company/db/pool.clj
@@ -144,26 +144,8 @@
     (dotimes [i size]
       (grow pool))))
 
-(def rethinkdb-pool
-  (do (when (bound? #'rethinkdb-pool) (shutdown-pool! rethinkdb-pool))
-      (fixed-pool init-conn rethinkdb.core/close {:size config/db-pool-size
-                                                  :regenerate-interval 15})))
-
-
 (comment
   (timbre/set-config! (assoc open-company.config/log-config :level :trace))
-
-  (.size (:queue rethinkdb-pool))
-
-  (rebuild-pool! rethinkdb-pool)
-
-  (shutdown-pool! rethinkdb-pool)
-
-  (def c (.poll (:queue rethinkdb-pool)))
-
-  (deref c)
-
-  (rethinkdb.core/close c)
 
   (defn repro []
     (let [mk-conn #(r/connect :host "127.0.0.1" :port 28015 :db "test")

--- a/src/open_company/representations/section.clj
+++ b/src/open_company/representations/section.clj
@@ -60,8 +60,8 @@
 (defn render-section
   "Create a JSON representation of the section for the REST API"
   ([conn section]
-    (render-section section true false))
+    (render-section conn section true false))
   ([conn section authorized]
-    (render-section section authorized false))
+    (render-section conn section authorized false))
   ([conn section authorized read-only]
     (json/generate-string (section-for-rendering conn section (and authorized (not read-only))) {:pretty true})))

--- a/src/open_company/representations/section.clj
+++ b/src/open_company/representations/section.clj
@@ -39,15 +39,6 @@
     (update-link company-slug section-name)
     (partial-update-link company-slug section-name)]))))
 
-(defn revision-links
-  "Add the HATEAOS revision links to the section"
-  ([section] (revision-links (:company-slug section) (:section-name section) section))
-
-  ([company-slug section-name section]
-  (assoc section :revisions (flatten
-    (map #(revision-link company-slug section-name (:updated-at %))
-      (section/list-revisions company-slug (name section-name)))))))
-
 (defn- clean
   "Remove properties of the section that aren't needed in the REST API representation"
   [section]
@@ -59,17 +50,18 @@
 
 (defn section-for-rendering
   "Get a representation of the section for the REST API"
-  [section authorized]
+  [conn {:keys [company-slug section-name] :as section} authorized]
   (-> section
-    (revision-links)
+    (assoc :revisions (section/list-revisions conn company-slug section-name))
+    (update :revisions #(map (fn [rev] (revision-link company-slug section-name (:updated-at rev))) %))
     (section-links authorized)
     (clean)))
 
 (defn render-section
   "Create a JSON representation of the section for the REST API"
-  ([section]
+  ([conn section]
     (render-section section true false))
-  ([section authorized]
+  ([conn section authorized]
     (render-section section authorized false))
-  ([section authorized read-only]
-    (json/generate-string (section-for-rendering section (and authorized (not read-only))) {:pretty true})))
+  ([conn section authorized read-only]
+    (json/generate-string (section-for-rendering conn section (and authorized (not read-only))) {:pretty true})))

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -8,8 +8,7 @@
             [clj-time.core :as time]
             [rethinkdb.query :as r]
             [open-company.lib.slugify :as slug]
-            [open-company.config :as config]
-            [open-company.db.pool :as pool]))
+            [open-company.config :as config]))
 
 ;; ----- RethinkDB metadata -----
 

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -222,9 +222,9 @@
   Given a table name, an index name and value, and a set of fields, retrieve
   the resources from the database in updated-at property order.
   "
-  [table-name index-name index-value fields]
+  [conn table-name index-name index-value fields]
   (updated-at-order
-    (read-resources table-name index-name index-value fields)))
+    (read-resources conn table-name index-name index-value fields)))
 
 (defn update-resource
   "Given a table name, the name of the primary key, and the original and updated resource,

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -175,56 +175,47 @@
 
 (defn create-resource
   "Create a resource in the DB, returning the property map for the resource."
-  [table-name resource timestamp]
+  [conn table-name resource timestamp]
   (let [timed-resource (merge resource {
           :created-at timestamp
           :updated-at timestamp})
-        insert (pool/with-pool [conn pool/rethinkdb-pool]
-                 (with-timeout default-timeout
-                   (-> (r/table table-name)
-                       (r/insert timed-resource)
-                       (r/run conn))))]
+        insert (with-timeout default-timeout
+                 (-> (r/table table-name)
+                     (r/insert timed-resource)
+                     (r/run conn)))]
   (if (= 1 (:inserted insert))
     timed-resource
     (throw (RuntimeException. (str "RethinkDB insert failure: " insert))))))
 
 (defn read-resource
-  "
-  Given a table name and a primary key value, retrieve the resource from the database,
-  or return nil if it doesn't exist.
-  "
-  [table-name primary-key-value]
-  (pool/with-pool [conn pool/rethinkdb-pool]
-    (-> (r/table table-name)
+  "Given a table name and a primary key value, retrieve the resource from the database,
+  or return nil if it doesn't exist."
+  [conn table-name primary-key-value]
+  (-> (r/table table-name)
       (r/get primary-key-value)
-      (r/run conn))))
+      (r/run conn)))
 
 (defn read-resources
-  "
-  Given a table name, and an optional index name and value, and an optional set of fields, retrieve
-  the resources from the database.
-  "
-  ([table-name fields]
-  (pool/with-pool [conn pool/rethinkdb-pool]
-    (with-timeout default-timeout
-      (-> (r/table table-name)
-          (r/with-fields fields)
-          (r/run conn)))))
+  "Given a table name, and an optional index name and value, and an optional set of fields, retrieve
+  the resources from the database."
+  ([conn table-name fields]
+   (with-timeout default-timeout
+     (-> (r/table table-name)
+         (r/with-fields fields)
+         (r/run conn))))
 
-  ([table-name index-name index-value]
-  (pool/with-pool [conn pool/rethinkdb-pool]
-    (with-timeout default-timeout
-      (-> (r/table table-name)
-          (r/get-all [index-value] {:index index-name})
-          (r/run conn)))))
+  ([conn table-name index-name index-value]
+   (with-timeout default-timeout
+     (-> (r/table table-name)
+         (r/get-all [index-value] {:index index-name})
+         (r/run conn))))
 
-  ([table-name index-name index-value fields]
-  (pool/with-pool [conn pool/rethinkdb-pool]
-    (with-timeout default-timeout
-      (-> (r/table table-name)
-          (r/get-all [index-value] {:index index-name})
-          (r/pluck fields)
-          (r/run conn))))))
+  ([conn table-name index-name index-value fields]
+   (with-timeout default-timeout
+     (-> (r/table table-name)
+         (r/get-all [index-value] {:index index-name})
+         (r/pluck fields)
+         (r/run conn)))))
 
 (defn read-resources-in-order
   "
@@ -238,44 +229,41 @@
 (defn update-resource
   "Given a table name, the name of the primary key, and the original and updated resource,
   update a resource in the DB, returning the property map for the resource."
-  ([table-name primary-key-name original-resource new-resource]
-  (update-resource table-name primary-key-name original-resource new-resource (current-timestamp)))
+  ([conn table-name primary-key-name original-resource new-resource]
+  (update-resource conn table-name primary-key-name original-resource new-resource (current-timestamp)))
 
-  ([table-name primary-key-name original-resource new-resource timestamp]
+  ([conn table-name primary-key-name original-resource new-resource timestamp]
   (let [timed-resource (merge new-resource {
           primary-key-name (original-resource primary-key-name)
           :created-at (:created-at original-resource)
           :updated-at timestamp})
-        update (pool/with-pool [conn pool/rethinkdb-pool]
-                 (with-timeout default-timeout
-                   (-> (r/table table-name)
-                       (r/get (original-resource primary-key-name))
-                       (r/replace timed-resource)
-                       (r/run conn))))]
+        update (with-timeout default-timeout
+                 (-> (r/table table-name)
+                     (r/get (original-resource primary-key-name))
+                     (r/replace timed-resource)
+                     (r/run conn)))]
   (if (or (= 1 (:replaced update)) (= 1 (:unchanged update)))
     timed-resource
     (throw (RuntimeException. (str "RethinkDB update failure: " update)))))))
 
 (defn delete-resource
   "Delete the specified resource and return `true`."
-  ([table-name primary-key-value]
-   (let [delete (pool/with-pool [conn pool/rethinkdb-pool]
-                  (with-timeout default-timeout
-                    (-> (r/table table-name)
-                        (r/get primary-key-value)
-                        (r/delete)
-                        (r/run conn))))]
+  ([conn table-name primary-key-value]
+   (let [delete (with-timeout default-timeout
+                  (-> (r/table table-name)
+                      (r/get primary-key-value)
+                      (r/delete)
+                      (r/run conn)))]
     (if (= 1 (:deleted delete))
       true
       (throw (RuntimeException. (str "RethinkDB delete failure: " delete))))))
 
-  ([table-name key-name key-value]
-   (let [delete (pool/with-pool [conn pool/rethinkdb-pool]
-                  (with-timeout default-timeout
-                    (-> (r/table table-name)
-                        (r/get-all [key-value] {:index key-name})
-                        (r/delete)
-                        (r/run conn))))]
+  ([conn table-name key-name key-value]
+   (let [delete (with-timeout default-timeout
+                  (-> (r/table table-name)
+                      (r/get-all [key-value] {:index key-name})
+                      (r/delete)
+                      (r/run conn)))]
      (if (zero? (:errors delete))
       true
       (throw (RuntimeException. (str "RethinkDB delete failure: " delete)))))))
@@ -284,12 +272,11 @@
 
 (defn delete-all-resources!
   "Use with caution! Failure can result in partial deletes of just some resources. Returns `true` if successful."
-  [table-name]
-  (let [delete (pool/with-pool [conn pool/rethinkdb-pool]
-                 (with-timeout default-timeout
-                   (-> (r/table table-name)
-                       (r/delete)
-                       (r/run conn))))]
+  [conn table-name]
+  (let [delete (with-timeout default-timeout
+                 (-> (r/table table-name)
+                     (r/delete)
+                     (r/run conn)))]
     (if (pos? (:errors delete))
       (throw (RuntimeException. (str "RethinkDB delete failure: " delete)))
       true)))

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -126,12 +126,9 @@
         ; names of sections in the sections property, but not present in company
         missing-section-names (map keyword (filter #(nil? (company (keyword %))) sections))
         ; IDs of the most recent prior section of those missing sections (where found)
-        prior-section-ids (map :id (flatten (remove nil? (map #(common/read-resources-in-order
-                                                                common/section-table-name
-                                                                "company-slug-section-name"
-                                                                [slug %]
-                                                                [:id]) missing-section-names))))
-        prior-sections (map #(common/read-resource common/section-table-name %) prior-section-ids)
+        read-in-order #(common/read-resources-in-order conn common/section-table-name "company-slug-section-name" [slug %] [:id])
+        prior-section-ids (->> missing-section-names (map read-in-order) (remove nil?) flatten (map :id))
+        prior-sections (map #(common/read-resource conn common/section-table-name %) prior-section-ids)
         prior-section-names (map #(keyword (:section-name %)) prior-sections)]
     (merge company (zipmap prior-section-names (map #(dissoc % :section-name) prior-sections)))))
 

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -1,8 +1,6 @@
 (ns open-company.resources.company
   (:require [medley.core :as med]
             [schema.core :as schema]
-            [defun :refer (defun)]
-            [open-company.lib.slugify :as slug]
             [open-company.resources.common :as common]))
 
 ;; ----- RethinkDB metadata -----

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -120,17 +120,17 @@
 (defn add-prior-sections
   "Add the most recent section revision (if there are any) for any section names listed in the :sections property
   of the company, but that aren't present in the company."
-  [company]
+  [conn company]
   (let [slug (:slug company)
         sections (-> company :sections vals flatten vec)
         ; names of sections in the sections property, but not present in company
         missing-section-names (map keyword (filter #(nil? (company (keyword %))) sections))
         ; IDs of the most recent prior section of those missing sections (where found)
         prior-section-ids (map :id (flatten (remove nil? (map #(common/read-resources-in-order
-                                                common/section-table-name
-                                                "company-slug-section-name"
-                                                [slug %]
-                                                [:id]) missing-section-names))))
+                                                                common/section-table-name
+                                                                "company-slug-section-name"
+                                                                [slug %]
+                                                                [:id]) missing-section-names))))
         prior-sections (map #(common/read-resource common/section-table-name %) prior-section-ids)
         prior-section-names (map #(keyword (:section-name %)) prior-sections)]
     (merge company (zipmap prior-section-names (map #(dissoc % :section-name) prior-sections)))))

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -108,11 +108,11 @@
   "Add the canonical placeholder section for any section names listed in the :sections property of the company,
   but that aren't present in the company."
   [company]
-  (let [sections (-> company :sections vals flatten vec)
-        missing-section-names (map keyword (filter #(nil? (company (keyword %))) sections))
-        missing-sections (map common/section-by-name missing-section-names)
-        ; add :placeholder flag and remove :core flag
-        placeholder-sections (map #(dissoc % :core) (map #(assoc % :placeholder true) missing-sections))]
+  (let [sections              (-> company :sections vals flatten vec)
+        missing-section-names (->> sections (map keyword) (remove #(get company %)))
+        missing-sections      (map common/section-by-name missing-section-names)
+        ;; add :placeholder flag and remove :core flag
+        placeholder-sections (->> missing-sections (map #(dissoc % :core)) (map #(assoc % :placeholder true)))]
     (merge company (zipmap missing-section-names placeholder-sections))))
 
 (defn add-prior-sections

--- a/src/user.clj
+++ b/src/user.clj
@@ -1,0 +1,40 @@
+(ns user
+  (:require [com.stuartsierra.component :as component]
+            [clojure.tools.namespace.repl :as ctnrepl]
+            [taoensso.timbre :as timbre]
+            
+            [open-company.config :as c]
+            [open-company.app :as app]
+            [open-company.components :as components]))
+
+(def system nil)
+
+(defn init []
+  (alter-var-root #'system (constantly (components/oc-system {:handler-fn app/app
+                                                              :port 3000}))))
+
+(defn start []
+  (alter-var-root #'system component/start))
+
+(defn stop []
+  (alter-var-root #'system (fn [s] (when s (component/stop s)))))
+
+(defn go []
+  (init)
+  (start))
+
+(defn reset []
+  (stop)
+  (ctnrepl/refresh :after 'user/go))
+
+(comment
+
+  (into {} system)
+
+  (go)
+
+  (do 
+    (clojure.tools.namespace.repl/set-refresh-dirs "src")
+    (reset))
+
+  )

--- a/src/user.clj
+++ b/src/user.clj
@@ -1,6 +1,7 @@
 (ns user
   (:require [com.stuartsierra.component :as component]
             [clojure.tools.namespace.repl :as ctnrepl]
+            [open-company.config :as c]
             [open-company.app :as app]
             [open-company.db.pool :as pool]
             [open-company.components :as components]))
@@ -8,9 +9,11 @@
 (def system nil)
 (def conn nil)
 
-(defn init []
+(defn init
+  ([] (init c/api-server-port))
+  ([port]
   (alter-var-root #'system (constantly (components/oc-system {:handler-fn app/app
-                                                              :port 3000}))))
+                                                              :port port})))))
 
 (defn bind-conn! []
   (alter-var-root #'conn (constantly (pool/claim (get-in system [:db-pool :pool])))))
@@ -21,10 +24,12 @@
 (defn stop []
   (alter-var-root #'system (fn [s] (when s (component/stop s)))))
 
-(defn go []
-  (init)
+(defn go
+  ([] (go c/api-server-port)) 
+  ([port]
+  (init port)
   (start)
-  (bind-conn!))
+  (bind-conn!)))
 
 (defn reset []
   (stop)

--- a/src/user.clj
+++ b/src/user.clj
@@ -2,13 +2,18 @@
   (:require [com.stuartsierra.component :as component]
             [clojure.tools.namespace.repl :as ctnrepl]
             [open-company.app :as app]
+            [open-company.db.pool :as pool]
             [open-company.components :as components]))
 
 (def system nil)
+(def conn nil)
 
 (defn init []
   (alter-var-root #'system (constantly (components/oc-system {:handler-fn app/app
                                                               :port 3000}))))
+
+(defn bind-conn! []
+  (alter-var-root #'conn (constantly (pool/claim (get-in system [:db-pool :pool])))))
 
 (defn start []
   (alter-var-root #'system component/start))
@@ -18,7 +23,8 @@
 
 (defn go []
   (init)
-  (start))
+  (start)
+  (bind-conn!))
 
 (defn reset []
   (stop)
@@ -30,7 +36,7 @@
 
   (go)
 
-  (do 
+  (do
     (clojure.tools.namespace.repl/set-refresh-dirs "src")
     (reset))
 

--- a/src/user.clj
+++ b/src/user.clj
@@ -1,9 +1,6 @@
 (ns user
   (:require [com.stuartsierra.component :as component]
             [clojure.tools.namespace.repl :as ctnrepl]
-            [taoensso.timbre :as timbre]
-            
-            [open-company.config :as c]
             [open-company.app :as app]
             [open-company.components :as components]))
 

--- a/test/open_company/integration/company/company_list.clj
+++ b/test/open_company/integration/company/company_list.clj
@@ -44,12 +44,6 @@
 (def options  "OPTIONS, GET")
 (def authenticated-options  "OPTIONS, GET, POST")
 
-
-;; (ts/setup-system!)
-;; (into {} (deref ts/test-system))
-
-;; (mock/api-request :get "/companies")
-
 (with-state-changes [(before :contents (ts/setup-system!))
                      (after :contents (ts/teardown-system!))
                      (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]

--- a/test/open_company/integration/company/company_list.clj
+++ b/test/open_company/integration/company/company_list.clj
@@ -4,14 +4,12 @@
             [open-company.lib.hateoas :as hateoas]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
+            [open-company.db.pool :as pool]
+            [open-company.lib.test-setup :as ts]
             [open-company.lib.slugify :refer (slugify)]
             [open-company.api.common :as common]
             [open-company.resources.company :as company]
             [open-company.representations.company :as company-rep]))
-
-;; ----- Startup -----
-
-(db/test-startup)
 
 ;; ----- Test Cases -----
 
@@ -46,12 +44,21 @@
 (def options  "OPTIONS, GET")
 (def authenticated-options  "OPTIONS, GET, POST")
 
-(with-state-changes [(before :facts (do
-                                      (company/delete-all-companies!)
-                                      (company/create-company! (company/->company r/open r/coyote))
-                                      (company/create-company! (company/->company r/uni r/camus))
-                                      (company/create-company! (company/->company r/buffer r/sartre))))
-                     (after :facts (company/delete-all-companies!))]
+
+;; (ts/setup-system!)
+;; (into {} (deref ts/test-system))
+
+;; (mock/api-request :get "/companies")
+
+(with-state-changes [(before :contents (ts/setup-system!))
+                     (after :contents (ts/teardown-system!))
+                     (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                      (company/delete-all-companies! conn)
+                                      (company/create-company! conn (company/->company r/open r/coyote))
+                                      (company/create-company! conn (company/->company r/uni r/camus (slugify (:name r/uni))))
+                                      (company/create-company! conn (company/->company r/buffer r/sartre))))
+                     (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                     (company/delete-all-companies! conn)))]
 
   (facts "about available options in listing companies"
 
@@ -104,7 +111,8 @@
           (hateoas/verify-link "self" "GET" (company-rep/url company) company-rep/media-type (:links company)))))
 
     (fact "removed companies are not listed"
-      (company/delete-company (:slug r/buffer))
+      (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+        (company/delete-company conn (:slug r/buffer)))
       (let [response (mock/api-request :get "/companies")
             body (mock/body-from-response response)
             companies (get-in body [:collection :companies])]

--- a/test/open_company/integration/company/company_retrieval.clj
+++ b/test/open_company/integration/company/company_retrieval.clj
@@ -127,13 +127,12 @@
         (:diversity body) => (contains r/text-section-2)
         (:values body) => (contains r/text-section-1)
          ;; verify each section has all the HATEOAS links
-        ;; (prn (:sections body))
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (hateoas/verify-section-links (:slug r/open) section-key (:links (body section-key))))
         ;; verify the company has all the HATEOAS links
         (hateoas/verify-company-links (:slug r/open) (:links body))))
 
-    #_(fact "anonymously with no JWToken"
+    (fact "anonymously with no JWToken"
       ;; retrieve with no JWToken
       (let [response (mock/api-request :get (company-rep/url r/open) {:skip-auth true})
             body (mock/body-from-response response)]
@@ -149,7 +148,7 @@
         (count (:links body)) => 1
         (hateoas/verify-link "self" GET (company-rep/url (:slug r/open)) company-rep/media-type (:links body))))
 
-    #_(fact "that doesn't match the retrieving user's organization"
+    (fact "that doesn't match the retrieving user's organization"
       ;; retrieve with Sartre (different org)
       (let [response (mock/api-request :get (company-rep/url r/open) {:auth mock/jwtoken-sartre})
             body (mock/body-from-response response)]

--- a/test/open_company/integration/company/company_retrieval.clj
+++ b/test/open_company/integration/company/company_retrieval.clj
@@ -4,6 +4,8 @@
             [open-company.lib.hateoas :as hateoas]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
+            [open-company.db.pool :as pool]
+            [open-company.lib.test-setup :as ts]
             [open-company.api.common :as common-api]
             [open-company.resources.common :as common]
             [open-company.resources.company :as company]
@@ -11,10 +13,6 @@
             [open-company.representations.common :refer (GET)]
             [open-company.representations.company :as company-rep]
             [open-company.representations.section :as section-rep]))
-
-;; ----- Startup -----
-
-(db/test-startup)
 
 ;; ----- Test Cases -----
 
@@ -53,15 +51,19 @@
 (def limited-options "OPTIONS, GET")
 (def full-options "OPTIONS, GET, PATCH, DELETE")
 
-(with-state-changes [(before :facts (do (company/delete-all-companies!)
-                                        (company/create-company! (company/->company r/open r/coyote))
-                                        (section/put-section r/slug :update r/text-section-1 r/coyote)
-                                        (section/put-section r/slug :finances r/finances-section-1 r/coyote)
-                                        (section/put-section r/slug :team r/text-section-2 r/coyote)
-                                        (section/put-section r/slug :help r/text-section-1 r/coyote)
-                                        (section/put-section r/slug :diversity r/text-section-2 r/coyote)
-                                        (section/put-section r/slug :values r/text-section-1 r/coyote)))
-                     (after :facts (company/delete-all-companies!))]
+(with-state-changes [(before :contents (ts/setup-system!))
+                     (after :contents (ts/teardown-system!))
+                     (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                      (company/delete-all-companies! conn)
+                                      (company/create-company! conn (company/->company r/open r/coyote))
+                                      (section/put-section conn r/slug :update r/text-section-1 r/coyote)
+                                      (section/put-section conn r/slug :finances r/finances-section-1 r/coyote)
+                                      (section/put-section conn r/slug :team r/text-section-2 r/coyote)
+                                      (section/put-section conn r/slug :help r/text-section-1 r/coyote)
+                                      (section/put-section conn r/slug :diversity r/text-section-2 r/coyote)
+                                      (section/put-section conn r/slug :values r/text-section-1 r/coyote)))
+                     (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                     (company/delete-all-companies! conn)))]
 
   (facts "about available options for retrieving a company"
 
@@ -125,12 +127,13 @@
         (:diversity body) => (contains r/text-section-2)
         (:values body) => (contains r/text-section-1)
          ;; verify each section has all the HATEOAS links
+        ;; (prn (:sections body))
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (hateoas/verify-section-links (:slug r/open) section-key (:links (body section-key))))
         ;; verify the company has all the HATEOAS links
         (hateoas/verify-company-links (:slug r/open) (:links body))))
 
-    (fact "anonymously with no JWToken"
+    #_(fact "anonymously with no JWToken"
       ;; retrieve with no JWToken
       (let [response (mock/api-request :get (company-rep/url r/open) {:skip-auth true})
             body (mock/body-from-response response)]
@@ -146,7 +149,7 @@
         (count (:links body)) => 1
         (hateoas/verify-link "self" GET (company-rep/url (:slug r/open)) company-rep/media-type (:links body))))
 
-    (fact "that doesn't match the retrieving user's organization"
+    #_(fact "that doesn't match the retrieving user's organization"
       ;; retrieve with Sartre (different org)
       (let [response (mock/api-request :get (company-rep/url r/open) {:auth mock/jwtoken-sartre})
             body (mock/body-from-response response)]

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -1,10 +1,10 @@
 (ns open-company.integration.section.section-manipulation
   (:require [midje.sweet :refer :all]
-            [open-company.db.pool :as pool]
-            [open-company.lib.test-setup :as ts]
             [open-company.lib.rest-api-mock :as mock]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
+            [open-company.db.pool :as pool]
+            [open-company.lib.test-setup :as ts]
             [open-company.api.common :as common]
             [open-company.resources.common :as common-res]
             [open-company.resources.company :as company]
@@ -54,8 +54,8 @@
                                       (section/put-section conn r/slug :values r/text-section-1 r/coyote)))
                      (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
                                      (company/delete-all-companies! conn)))]
-  (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
 
+  (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
   (facts "about failing to reorder sections"
 
     (fact "with an invalid JWToken"
@@ -156,228 +156,224 @@
           (:sections (company/get-company conn r/slug)) => new-order))
 
       (fact "the section order in the progress and company category can both be adjusted at once"
-        (let [new-order {:progress ["help" "update"]
+        (let [new-order {:progress ["help" "team" "update"]
                          :financial ["finances"]
                          :company ["values" "diversity"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-              company  (company/get-company conn r/slug)]
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
-          (:sections company) => new-order
-          (:growth company) => falsey
-          (:challenges company) => falsey
-          (:team company) => falsey
-          (:product company) => falsey
-          (:mission company) => falsey)))
+          (:sections (mock/body-from-response response)) => new-order
+          ;; verify the new order
+          (:sections (company/get-company conn r/slug)) => new-order)))
 
-    (facts "about section removal"
+    (future-facts "when the new order is NOT valid"))
 
-      (facts "about placeholder section removal"
-        (let [slug     "hello-world"
-              payload  {:name "Hello World" :description "x" :slug slug}
-              response (mock/api-request :post "/companies" {:body payload})
-              company  (company/get-company conn slug)]
-          ;; ensure all placeholder sections are in company
-          (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
-                                  :financial ["finances"]
-                                  :company ["mission" "values"]}
-          (:growth company) => truthy
-          (:challenges company) => truthy
-          (:team company) => truthy
-          (:product company) => truthy
-          (:mission company) => truthy
-          (let [new-set {:company ["values"]
-                         :progress ["update" "finances" "help"]
+  (facts "about placeholder section removal"
+    (let [slug     "hello-world"
+          payload  {:name "Hello World" :description "x"}
+          response (mock/api-request :post "/companies" {:body payload})
+          company  (company/get-company conn slug)]
+      ;; ensure all placeholder sections are in company
+      (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
+                              :financial ["finances"]
+                              :company ["mission" "values"]}
+      (:growth company) => truthy
+      (:challenges company) => truthy
+      (:team company) => truthy
+      (:product company) => truthy
+      (:mission company) => truthy
+      (let [new-set {:company ["values"]
+                     :progress ["update" "finances" "help"]
+                     :financial []}
+            response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
+            body     (mock/body-from-response response)
+            company  (company/get-company conn slug)]
+        (:status response) => 200
+        (:sections company) => new-set
+        (:growth company) => falsey
+        (:challenges company) => falsey
+        (:team company) => falsey
+        (:product company) => falsey
+        (:mission company) => falsey)))
+
+  (facts "about section removal"
+
+    ;; verify the initial set of sections
+    (:sections (company/get-company conn r/slug)) => {:company ["help" "diversity" "values"]
+                                                 :progress ["update" "team"]
+                                                 :financial ["finances"]}
+
+      (fact "a section can be removed from the progress category"
+        (let [new-set {:company ["help" "diversity" "values"]
+                       :progress ["update"]
+                       :financial ["finances"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+              body (mock/body-from-response response)
+              db-company (company/get-company conn r/slug)]
+          (:status response) => 200
+          (:sections body) => new-set
+          (:update body) => (contains r/text-section-1)
+          (:finances body) => (contains r/finances-section-1)
+          (:team body) => nil
+          (:help body) => (contains r/text-section-1)
+          (:diversity body) => (contains r/text-section-2)
+          (:values body) => (contains r/text-section-1)
+          ;; verify the new set
+          (:sections db-company) => new-set
+          (:update db-company) => (contains r/text-section-1)
+          (:finances db-company) => (contains r/finances-section-1)
+          (:team db-company) => nil
+          (:help db-company) => (contains r/text-section-1)
+          (:diversity db-company) => (contains r/text-section-2)
+          (:values db-company) => (contains r/text-section-1)))
+
+      (fact "multiple sections can be removed from the progress category"
+        (let [new-set {:company ["help" "diversity" "values"]
+                       :progress []
+                       :financial ["finances"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+              body (mock/body-from-response response)
+              db-company (company/get-company conn r/slug)]
+          (:status response) => 200
+          (:sections body) => new-set
+          (:update body) => nil
+          (:team body) => nil
+          (:finances body) => (contains r/finances-section-1)
+          (:help body) => (contains r/text-section-1)
+          (:diversity body) => (contains r/text-section-2)
+          (:values body) => (contains r/text-section-1)
+          ;; verify the new set
+          (:sections db-company) => new-set
+          (:update db-company) => nil
+          (:team db-company) => nil
+          (:finances db-company) => (contains r/finances-section-1)
+          (:help db-company) => (contains r/text-section-1)
+          (:diversity db-company) => (contains r/text-section-2)
+          (:values db-company) => (contains r/text-section-1)))
+
+      (fact "a section can be removed from the company category"
+        (let [new-order {:company ["help" "diversity"]
+                         :progress ["update" "team"]
+                         :financial ["finances"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+              body (mock/body-from-response response)
+              db-company (company/get-company conn r/slug)]
+          (:status response) => 200
+          (:sections body) => new-order
+          (:update body) => (contains r/text-section-1)
+          (:finances body) => (contains r/finances-section-1)
+          (:team body) => (contains r/text-section-2)
+          (:help body) => (contains r/text-section-1)
+          (:diversity body) => (contains r/text-section-2)
+          (:values body) => nil
+          ;; verify the new set
+          (:sections db-company) => new-order
+          (:update db-company) => (contains r/text-section-1)
+          (:finances db-company) => (contains r/finances-section-1)
+          (:team db-company) => (contains r/text-section-2)
+          (:help db-company) => (contains r/text-section-1)
+          (:diversity db-company) => (contains r/text-section-2)
+          (:values db-company) => nil))
+
+      (fact "sections can be removed from all the categories at once"
+        (let [new-order {:company ["values"]
+                         :progress ["update" "help"]
                          :financial []}
-                response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
-                body     (mock/body-from-response response)
-                company  (company/get-company conn slug)]
-            (:status response) => 200
-            (:sections company) => new-set
-            (:growth company) => falsey
-            (:challenges company) => falsey
-            (:team company) => falsey
-            (:product company) => falsey
-            (:mission company) => falsey)))
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+              body (mock/body-from-response response)
+              db-company (company/get-company conn r/slug)]
+          (:status response) => 200
+          (:sections body) => new-order
+          (:update body) => (contains r/text-section-1)
+          (:finances body) => nil
+          (:team body) => nil
+          (:help body) => (contains r/text-section-1)
+          (:diversity body) => nil
+          (:values body) => (contains r/text-section-1)
+          ;; verify the new set
+          (:sections db-company) => new-order
+          (:update db-company) => (contains r/text-section-1)
+          (:finances db-company) => nil
+          (:team db-company) => nil
+          (:help db-company) => (contains r/text-section-1)
+          (:diversity db-company) => nil
+          (:values db-company) => (contains r/text-section-1))))
+  
+  (facts "about adding sections"
 
-      (facts "about section removal"
+    (fact "that don't really exist"
+      (let [new-sections {:company [] :progress ["health"] :financial []}
+            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+            body (mock/body-from-response response)]
+        (:status response) => 422))
 
-        ;; verify the initial set of sections
-        (:sections (company/get-company conn r/slug)) => {:company ["help" "diversity" "values"]
-                                                          :progress ["update" "team"]
-                                                          :financial ["finances"]}
+    (facts "without any section content"
+    
+      (fact "that never existed"
+        (let [new-sections {:company [] :progress ["highlights"] :financial []}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+              body (mock/body-from-response response)
+              resp-highlights (:highlights body)
+              db-company (company/get-company conn r/slug)
+              db-highlights (:highlights db-company)
+              placeholder (dissoc (common-res/section-by-name :highlights) :section-name :core)]
+          (:status response) => 200
+          (:sections body) => new-sections
+          ; verify placeholder flag and content in response
+          (:placeholder resp-highlights) => true 
+          resp-highlights => (contains placeholder)
+          ; verify placeholder flag and content in DB
+          (:placeholder db-highlights) => true
+          db-highlights => (contains placeholder)))
 
-        (fact "a section can be removed from the progress category"
-          (let [new-set {:company ["help" "diversity" "values"]
-                         :progress ["update"]
-                         :financial ["finances"]}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+      (future-fact "that used to exist"
+        (let [new-sections {:company [] :progress [] :financial []}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+              body (mock/body-from-response response)
+              db-company (company/get-company conn r/slug)]
+          (:status response) => 200
+          (:sections body) => new-sections
+          ; verify update is not in the response
+          (:update body) => nil
+          ; verify update not in the DB
+          (:update db-company) => nil)
+        (let [new-sections {:company [] :progress ["update"] :financial []}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+              body (mock/body-from-response response)
+              db-company (company/get-company conn r/slug)]
+          (:status response) => 200
+          (:sections body) => new-sections
+          ; verify update is not in the response
+          (:update body) => (contains r/text-section-1)
+          ; verify update not in the DB
+          (:update db-company) => (contains r/text-section-1))))
+
+    (facts "with section content"
+
+      (let [new-sections {:company ["help" "diversity" "values"]
+                            :progress ["update" "team" "kudos"]
+                            :financial ["finances"]}
+            kudos-placeholder (common-res/section-by-name "kudos")]
+
+        (future-fact "with minimal content"
+          (let [kudos-content {:body "Fred is killing it"}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                 :kudos kudos-content}})
                 body (mock/body-from-response response)
                 db-company (company/get-company conn r/slug)]
             (:status response) => 200
-            (:sections body) => new-set
-            (:update body) => (contains r/text-section-1)
-            (:finances body) => (contains r/finances-section-1)
-            (:team body) => nil
-            (:help body) => (contains r/text-section-1)
-            (:diversity body) => (contains r/text-section-2)
-            (:values body) => (contains r/text-section-1)
-            ;; verify the new set
-            (:sections db-company) => new-set
-            (:update db-company) => (contains r/text-section-1)
-            (:finances db-company) => (contains r/finances-section-1)
-            (:team db-company) => nil
-            (:help db-company) => (contains r/text-section-1)
-            (:diversity db-company) => (contains r/text-section-2)
-            (:values db-company) => (contains r/text-section-1)))
+            (:body response) => nil))
 
-        (fact "multiple sections can be removed from the progress category"
-          (let [new-set {:company ["help" "diversity" "values"]
-                         :progress []
-                         :financial ["finances"]}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+        (future-fact "with maximal content"
+          (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                   :kudos kudos-content}})
                 body (mock/body-from-response response)
                 db-company (company/get-company conn r/slug)]
             (:status response) => 200
-            (:sections body) => new-set
-            (:update body) => nil
-            (:team body) => nil
-            (:finances body) => (contains r/finances-section-1)
-            (:help body) => (contains r/text-section-1)
-            (:diversity body) => (contains r/text-section-2)
-            (:values body) => (contains r/text-section-1)
-            ;; verify the new set
-            (:sections db-company) => new-set
-            (:update db-company) => nil
-            (:team db-company) => nil
-            (:finances db-company) => (contains r/finances-section-1)
-            (:help db-company) => (contains r/text-section-1)
-            (:diversity db-company) => (contains r/text-section-2)
-            (:values db-company) => (contains r/text-section-1)))
+            (:body response) => nil))
 
-        (fact "a section can be removed from the company category"
-          (let [new-order {:company ["help" "diversity"]
-                           :progress ["update" "team"]
-                           :financial ["finances"]}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-                body (mock/body-from-response response)
-                db-company (company/get-company conn r/slug)]
-            (:status response) => 200
-            (:sections body) => new-order
-            (:update body) => (contains r/text-section-1)
-            (:finances body) => (contains r/finances-section-1)
-            (:team body) => (contains r/text-section-2)
-            (:help body) => (contains r/text-section-1)
-            (:diversity body) => (contains r/text-section-2)
-            (:values body) => nil
-            ;; verify the new set
-            (:sections db-company) => new-order
-            (:update db-company) => (contains r/text-section-1)
-            (:finances db-company) => (contains r/finances-section-1)
-            (:team db-company) => (contains r/text-section-2)
-            (:help db-company) => (contains r/text-section-1)
-            (:diversity db-company) => (contains r/text-section-2)
-            (:values db-company) => nil))
-
-        (fact "sections can be removed from all the categories at once"
-          (let [new-order {:company ["values"]
-                           :progress ["update" "help"]
-                           :financial []}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-                body (mock/body-from-response response)
-                db-company (company/get-company conn r/slug)]
-            (:status response) => 200
-            (:sections body) => new-order
-            (:update body) => (contains r/text-section-1)
-            (:finances body) => nil
-            (:team body) => nil
-            (:help body) => (contains r/text-section-1)
-            (:diversity body) => nil
-            (:values body) => (contains r/text-section-1)
-            ;; verify the new set
-            (:sections db-company) => new-order
-            (:update db-company) => (contains r/text-section-1)
-            (:finances db-company) => nil
-            (:team db-company) => nil
-            (:help db-company) => (contains r/text-section-1)
-            (:diversity db-company) => nil
-            (:values db-company) => (contains r/text-section-1))))
+        (future-fact "with too much content"
       
-      (facts "about adding sections"
+          (future-fact "extra properties aren't allowed")
 
-        (fact "that don't really exist"
-          (let [new-sections {:company [] :progress ["health"] :financial []}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                body (mock/body-from-response response)]
-            (:status response) => 422))
-
-        (facts "without any section content"
-          
-          (fact "that never existed"
-            (let [new-sections {:company [] :progress ["highlights"] :financial []}
-                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                  body (mock/body-from-response response)
-                  resp-highlights (:highlights body)
-                  db-company (company/get-company conn r/slug)
-                  db-highlights (:highlights db-company)
-                  placeholder (dissoc (common-res/section-by-name :highlights) :section-name :core)]
-              (:status response) => 200
-              (:sections body) => new-sections
-              ;; verify placeholder flag and content in response
-              (:placeholder resp-highlights) => true 
-              resp-highlights => (contains placeholder)
-              ;; verify placeholder flag and content in DB
-              (:placeholder db-highlights) => true
-              db-highlights => (contains placeholder)))
-
-          (future-fact "that used to exist"
-            (let [new-sections {:company [] :progress [] :financial []}
-                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                  body (mock/body-from-response response)
-                  db-company (company/get-company conn r/slug)]
-              (:status response) => 200
-              (:sections body) => new-sections
-              ;; verify update is not in the response
-              (:update body) => nil
-              ;; verify update not in the DB
-              (:update db-company) => nil)
-            (let [new-sections {:company [] :progress ["update"] :financial []}
-                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                  body (mock/body-from-response response)
-                  db-company (company/get-company conn r/slug)]
-              (:status response) => 200
-              (:sections body) => new-sections
-              ;; verify update is not in the response
-              (:update body) => (contains r/text-section-1)
-              ;; verify update not in the DB
-              (:update db-company) => (contains r/text-section-1))))
-
-        (facts "with section content"
-
-          (let [new-sections {:company ["help" "diversity" "values"]
-                              :progress ["update" "team" "kudos"]
-                              :financial ["finances"]}
-                kudos-placeholder (common-res/section-by-name "kudos")]
-
-            (future-fact "with minimal content"
-              (let [kudos-content {:body "Fred is killing it"}
-                    response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                       :kudos kudos-content}})
-                    body (mock/body-from-response response)
-                    db-company (company/get-company conn r/slug)]
-                (:status response) => 200
-                (:body response) => nil))
-
-            (future-fact "with maximal content"
-              (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
-                    response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                       :kudos kudos-content}})
-                    body (mock/body-from-response response)
-                    db-company (company/get-company conn r/slug)]
-                (:status response) => 200
-                (:body response) => nil))
-
-            (future-fact "with too much content"
-              
-              (future-fact "extra properties aren't allowed")
-
-              (future-fact "read/only properties are ignored")))))))))
+          (future-fact "read/only properties are ignored")))))))

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -322,34 +322,34 @@
                   placeholder (dissoc (common-res/section-by-name :highlights) :section-name :core)]
               (:status response) => 200
               (:sections body) => new-sections
-                                      ; verify placeholder flag and content in response
+              ;; verify placeholder flag and content in response
               (:placeholder resp-highlights) => true 
               resp-highlights => (contains placeholder)
-                                      ; verify placeholder flag and content in DB
+              ;; verify placeholder flag and content in DB
               (:placeholder db-highlights) => true
               db-highlights => (contains placeholder)))
 
           (future-fact "that used to exist"
-                       (let [new-sections {:company [] :progress [] :financial []}
-                             response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                             body (mock/body-from-response response)
-                             db-company (company/get-company conn r/slug)]
-                         (:status response) => 200
-                         (:sections body) => new-sections
-                                      ; verify update is not in the response
-                         (:update body) => nil
-                                      ; verify update not in the DB
-                         (:update db-company) => nil)
-                       (let [new-sections {:company [] :progress ["update"] :financial []}
-                             response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                             body (mock/body-from-response response)
-                             db-company (company/get-company conn r/slug)]
-                         (:status response) => 200
-                         (:sections body) => new-sections
-                                      ; verify update is not in the response
-                         (:update body) => (contains r/text-section-1)
-                                      ; verify update not in the DB
-                         (:update db-company) => (contains r/text-section-1))))
+            (let [new-sections {:company [] :progress [] :financial []}
+                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                  body (mock/body-from-response response)
+                  db-company (company/get-company conn r/slug)]
+              (:status response) => 200
+              (:sections body) => new-sections
+              ;; verify update is not in the response
+              (:update body) => nil
+              ;; verify update not in the DB
+              (:update db-company) => nil)
+            (let [new-sections {:company [] :progress ["update"] :financial []}
+                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                  body (mock/body-from-response response)
+                  db-company (company/get-company conn r/slug)]
+              (:status response) => 200
+              (:sections body) => new-sections
+              ;; verify update is not in the response
+              (:update body) => (contains r/text-section-1)
+              ;; verify update not in the DB
+              (:update db-company) => (contains r/text-section-1))))
 
         (facts "with section content"
 
@@ -359,25 +359,25 @@
                 kudos-placeholder (common-res/section-by-name "kudos")]
 
             (future-fact "with minimal content"
-                         (let [kudos-content {:body "Fred is killing it"}
-                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                                  :kudos kudos-content}})
-                               body (mock/body-from-response response)
-                               db-company (company/get-company conn r/slug)]
-                           (:status response) => 200
-                           (:body response) => nil))
+              (let [kudos-content {:body "Fred is killing it"}
+                    response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                       :kudos kudos-content}})
+                    body (mock/body-from-response response)
+                    db-company (company/get-company conn r/slug)]
+                (:status response) => 200
+                (:body response) => nil))
 
             (future-fact "with maximal content"
-                         (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
-                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                                  :kudos kudos-content}})
-                               body (mock/body-from-response response)
-                               db-company (company/get-company conn r/slug)]
-                           (:status response) => 200
-                           (:body response) => nil))
+              (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
+                    response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                       :kudos kudos-content}})
+                    body (mock/body-from-response response)
+                    db-company (company/get-company conn r/slug)]
+                (:status response) => 200
+                (:body response) => nil))
 
             (future-fact "with too much content"
-                         
-                         (future-fact "extra properties aren't allowed")
+              
+              (future-fact "extra properties aren't allowed")
 
-                         (future-fact "read/only properties are ignored")))))))))
+              (future-fact "read/only properties are ignored")))))))))

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -56,113 +56,143 @@
                                      (company/delete-all-companies! conn)))]
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
 
-    (facts "about failing to reorder sections"
+  (facts "about failing to reorder sections"
 
-      (fact "with an invalid JWToken"
-        (let [new-order {:progress ["team" "update" "finances" "help"]
-                         :company ["diversity" "values"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
-                                                                          :auth mock/jwtoken-bad})]
-          (:status response) => 401
-          (:body response) => common/unauthorized)
-        ;; verify the initial order is unchanged
-        (let [db-company (company/get-company conn r/slug)]
-          (:categories db-company) => categories
-          (:sections db-company) => {:company ["help" "diversity" "values"]
-                                     :progress ["update" "team"]
-                                     :financial ["finances"]}))
+    (fact "with an invalid JWToken"
+      (let [new-order {:progress ["team" "update" "finances" "help"]
+                       :company ["diversity" "values"]}
+            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
+                                                                        :auth mock/jwtoken-bad})]
+        (:status response) => 401
+        (:body response) => common/unauthorized)
+      ;; verify the initial order is unchanged
+      (let [db-company (company/get-company conn r/slug)]
+        (:categories db-company) => categories
+        (:sections db-company) => {:company ["help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]}))
 
-      (fact "with no JWToken"
-        (let [new-order {:progress ["team" "update" "finances" "help"]
-                         :company ["diversity" "values"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
-                                                                          :skip-auth true})]
-          (:status response) => 401
-          (:body response) => common/unauthorized)
-        ;; verify the initial order is unchanged
-        (let [db-company (company/get-company conn r/slug)]
-          (:categories db-company) => categories
-          (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                     :progress ["update" "team"]
-                                     :financial ["finances"]}))
-
-      (fact "with an organization that doesn't match the company"
-        (let [new-order {:progress ["team" "update" "finances" "help"]
-                         :company ["diversity" "values"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
-                                                                          :auth mock/jwtoken-sartre})]
-          (:status response) => 403
-          (:body response) => common/forbidden)
-        ;; verify the initial order is unchanged
-        (let [db-company (company/get-company conn r/slug)]
-          (:categories db-company) => categories
-          (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                     :progress ["update" "team"]
-                                     :financial ["finances"]}))
-
-      (fact "with no company matching the company slug"
-        (let [new-order {:company ["diversity" "values"]
-                         :progress ["team" "update" "finances" "help"]
-                         :financial []}
-              response (mock/api-request :patch (company-rep/url "foo") {:body {:sections new-order}})]
-          (:status response) => 404
-          (:body response) => "")
-        ;; verify the initial order is unchanged
-        (let [db-company (company/get-company conn r/slug)]
-          (:categories db-company) => categories
-          (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                     :progress ["update" "team"]
-                                     :financial ["finances"]})))
-
-    (facts "about section reordering"
-
-      ;; verify the initial order
+    (fact "with no JWToken"
+      (let [new-order {:progress ["team" "update" "finances" "help"]
+                       :company ["diversity" "values"]}
+            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
+                                                                        :skip-auth true})]
+        (:status response) => 401
+        (:body response) => common/unauthorized)
+      ;; verify the initial order is unchanged
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company [ "help" "diversity" "values"]
                                    :progress ["update" "team"]
-                                   :financial ["finances"]})
+                                   :financial ["finances"]}))
 
-      (facts "when the new order is valid"
+    (fact "with an organization that doesn't match the company"
+      (let [new-order {:progress ["team" "update" "finances" "help"]
+                       :company ["diversity" "values"]}
+            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
+                                                                        :auth mock/jwtoken-sartre})]
+        (:status response) => 403
+        (:body response) => common/forbidden)
+      ;; verify the initial order is unchanged
+      (let [db-company (company/get-company conn r/slug)]
+        (:categories db-company) => categories
+        (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]}))
 
-        (fact "the section order in the progress category can be gently adjusted"
-          (let [new-order {:progress ["team" "update" "help"]
-                           :financial ["finances"]
-                           :company ["diversity" "values"]}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
+    (fact "with no company matching the company slug"
+      (let [new-order {:company ["diversity" "values"]
+                       :progress ["team" "update" "finances" "help"]
+                       :financial []}
+            response (mock/api-request :patch (company-rep/url "foo") {:body {:sections new-order}})]
+        (:status response) => 404
+        (:body response) => "")
+      ;; verify the initial order is unchanged
+      (let [db-company (company/get-company conn r/slug)]
+        (:categories db-company) => categories
+        (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]})))
+
+  (facts "about section reordering"
+
+    ;; verify the initial order
+    (let [db-company (company/get-company conn r/slug)]
+      (:categories db-company) => categories
+      (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                 :progress ["update" "team"]
+                                 :financial ["finances"]})
+
+    (facts "when the new order is valid"
+
+      (fact "the section order in the progress category can be gently adjusted"
+        (let [new-order {:progress ["team" "update" "help"]
+                         :financial ["finances"]
+                         :company ["diversity" "values"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
+          (:status response) => 200
+          (:sections (mock/body-from-response response)) => new-order
+          ;; verify the new order
+          (:sections (company/get-company conn r/slug)) => new-order))
+
+      (fact "the sections order in the progress category can be greatly adjusted"
+        (let [new-order {:progress ["help" "team" "update"]
+                         :financial ["finances"]
+                         :company ["diversity" "values"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
+          (:status response) => 200
+          (:sections (mock/body-from-response response)) => new-order
+          ;; verify the new order
+          (:sections (company/get-company conn r/slug)) => new-order))
+
+      (fact "the section order in the company category can be adjusted"
+        (let [new-order {:progress ["update" "team" "help"]
+                         :financial ["finances"]
+                         :company ["values" "diversity"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
+          (:status response) => 200
+          (:sections (mock/body-from-response response)) => new-order
+          ;; verify the new order
+          (:sections (company/get-company conn r/slug)) => new-order))
+
+      (fact "the section order in the progress and company category can both be adjusted at once"
+        (let [new-order {:progress ["help" "update"]
+                         :financial ["finances"]
+                         :company ["values" "diversity"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+              company  (company/get-company conn r/slug)]
+          (:status response) => 200
+          (:sections company) => new-order
+          (:growth company) => falsey
+          (:challenges company) => falsey
+          (:team company) => falsey
+          (:product company) => falsey
+          (:mission company) => falsey)))
+
+    (facts "about section removal"
+
+      (facts "about placeholder section removal"
+        (let [slug     "hello-world"
+              payload  {:name "Hello World" :description "x" :slug slug}
+              response (mock/api-request :post "/companies" {:body payload})
+              company  (company/get-company conn slug)]
+          ;; ensure all placeholder sections are in company
+          (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
+                                  :financial ["finances"]
+                                  :company ["mission" "values"]}
+          (:growth company) => truthy
+          (:challenges company) => truthy
+          (:team company) => truthy
+          (:product company) => truthy
+          (:mission company) => truthy
+          (let [new-set {:company ["values"]
+                         :progress ["update" "finances" "help"]
+                         :financial []}
+                response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
+                body     (mock/body-from-response response)
+                company  (company/get-company conn slug)]
             (:status response) => 200
-            (:sections (mock/body-from-response response)) => new-order
-            ;; verify the new order
-            (:sections (company/get-company conn r/slug)) => new-order))
-
-        (fact "the sections order in the progress category can be greatly adjusted"
-          (let [new-order {:progress ["help" "team" "update"]
-                           :financial ["finances"]
-                           :company ["diversity" "values"]}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
-            (:status response) => 200
-            (:sections (mock/body-from-response response)) => new-order
-            ;; verify the new order
-            (:sections (company/get-company conn r/slug)) => new-order))
-
-        (fact "the section order in the company category can be adjusted"
-          (let [new-order {:progress ["update" "team" "help"]
-                           :financial ["finances"]
-                           :company ["values" "diversity"]}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
-            (:status response) => 200
-            (:sections (mock/body-from-response response)) => new-order
-            ;; verify the new order
-            (:sections (company/get-company conn r/slug)) => new-order))
-
-        (fact "the section order in the progress and company category can both be adjusted at once"
-          (let [new-order {:progress ["help" "update"]
-                           :financial ["finances"]
-                           :company ["values" "diversity"]}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-                company  (company/get-company conn r/slug)]
-            (:status response) => 200
-            (:sections company) => new-order
+            (:sections company) => new-set
             (:growth company) => falsey
             (:challenges company) => falsey
             (:team company) => falsey
@@ -171,213 +201,183 @@
 
       (facts "about section removal"
 
-        (facts "about placeholder section removal"
-          (let [slug     "hello-world"
-                payload  {:name "Hello World" :description "x" :slug slug}
-                response (mock/api-request :post "/companies" {:body payload})
-                company  (company/get-company conn slug)]
-            ;; ensure all placeholder sections are in company
-            (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
-                                    :financial ["finances"]
-                                    :company ["mission" "values"]}
-            (:growth company) => truthy
-            (:challenges company) => truthy
-            (:team company) => truthy
-            (:product company) => truthy
-            (:mission company) => truthy
-            (let [new-set {:company ["values"]
-                           :progress ["update" "finances" "help"]
+        ;; verify the initial set of sections
+        (:sections (company/get-company conn r/slug)) => {:company ["help" "diversity" "values"]
+                                                          :progress ["update" "team"]
+                                                          :financial ["finances"]}
+
+        (fact "a section can be removed from the progress category"
+          (let [new-set {:company ["help" "diversity" "values"]
+                         :progress ["update"]
+                         :financial ["finances"]}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+                body (mock/body-from-response response)
+                db-company (company/get-company conn r/slug)]
+            (:status response) => 200
+            (:sections body) => new-set
+            (:update body) => (contains r/text-section-1)
+            (:finances body) => (contains r/finances-section-1)
+            (:team body) => nil
+            (:help body) => (contains r/text-section-1)
+            (:diversity body) => (contains r/text-section-2)
+            (:values body) => (contains r/text-section-1)
+            ;; verify the new set
+            (:sections db-company) => new-set
+            (:update db-company) => (contains r/text-section-1)
+            (:finances db-company) => (contains r/finances-section-1)
+            (:team db-company) => nil
+            (:help db-company) => (contains r/text-section-1)
+            (:diversity db-company) => (contains r/text-section-2)
+            (:values db-company) => (contains r/text-section-1)))
+
+        (fact "multiple sections can be removed from the progress category"
+          (let [new-set {:company ["help" "diversity" "values"]
+                         :progress []
+                         :financial ["finances"]}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+                body (mock/body-from-response response)
+                db-company (company/get-company conn r/slug)]
+            (:status response) => 200
+            (:sections body) => new-set
+            (:update body) => nil
+            (:team body) => nil
+            (:finances body) => (contains r/finances-section-1)
+            (:help body) => (contains r/text-section-1)
+            (:diversity body) => (contains r/text-section-2)
+            (:values body) => (contains r/text-section-1)
+            ;; verify the new set
+            (:sections db-company) => new-set
+            (:update db-company) => nil
+            (:team db-company) => nil
+            (:finances db-company) => (contains r/finances-section-1)
+            (:help db-company) => (contains r/text-section-1)
+            (:diversity db-company) => (contains r/text-section-2)
+            (:values db-company) => (contains r/text-section-1)))
+
+        (fact "a section can be removed from the company category"
+          (let [new-order {:company ["help" "diversity"]
+                           :progress ["update" "team"]
+                           :financial ["finances"]}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+                body (mock/body-from-response response)
+                db-company (company/get-company conn r/slug)]
+            (:status response) => 200
+            (:sections body) => new-order
+            (:update body) => (contains r/text-section-1)
+            (:finances body) => (contains r/finances-section-1)
+            (:team body) => (contains r/text-section-2)
+            (:help body) => (contains r/text-section-1)
+            (:diversity body) => (contains r/text-section-2)
+            (:values body) => nil
+            ;; verify the new set
+            (:sections db-company) => new-order
+            (:update db-company) => (contains r/text-section-1)
+            (:finances db-company) => (contains r/finances-section-1)
+            (:team db-company) => (contains r/text-section-2)
+            (:help db-company) => (contains r/text-section-1)
+            (:diversity db-company) => (contains r/text-section-2)
+            (:values db-company) => nil))
+
+        (fact "sections can be removed from all the categories at once"
+          (let [new-order {:company ["values"]
+                           :progress ["update" "help"]
                            :financial []}
-                  response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
-                  body     (mock/body-from-response response)
-                  company  (company/get-company conn slug)]
-              (:status response) => 200
-              (:sections company) => new-set
-              (:growth company) => falsey
-              (:challenges company) => falsey
-              (:team company) => falsey
-              (:product company) => falsey
-              (:mission company) => falsey)))
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+                body (mock/body-from-response response)
+                db-company (company/get-company conn r/slug)]
+            (:status response) => 200
+            (:sections body) => new-order
+            (:update body) => (contains r/text-section-1)
+            (:finances body) => nil
+            (:team body) => nil
+            (:help body) => (contains r/text-section-1)
+            (:diversity body) => nil
+            (:values body) => (contains r/text-section-1)
+            ;; verify the new set
+            (:sections db-company) => new-order
+            (:update db-company) => (contains r/text-section-1)
+            (:finances db-company) => nil
+            (:team db-company) => nil
+            (:help db-company) => (contains r/text-section-1)
+            (:diversity db-company) => nil
+            (:values db-company) => (contains r/text-section-1))))
+      
+      (facts "about adding sections"
 
-        (facts "about section removal"
+        (fact "that don't really exist"
+          (let [new-sections {:company [] :progress ["health"] :financial []}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                body (mock/body-from-response response)]
+            (:status response) => 422))
 
-          ;; verify the initial set of sections
-          (:sections (company/get-company conn r/slug)) => {:company ["help" "diversity" "values"]
-                                                            :progress ["update" "team"]
-                                                            :financial ["finances"]}
-
-          (fact "a section can be removed from the progress category"
-            (let [new-set {:company ["help" "diversity" "values"]
-                           :progress ["update"]
-                           :financial ["finances"]}
-                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
-                  body (mock/body-from-response response)
-                  db-company (company/get-company conn r/slug)]
-              (:status response) => 200
-              (:sections body) => new-set
-              (:update body) => (contains r/text-section-1)
-              (:finances body) => (contains r/finances-section-1)
-              (:team body) => nil
-              (:help body) => (contains r/text-section-1)
-              (:diversity body) => (contains r/text-section-2)
-              (:values body) => (contains r/text-section-1)
-              ;; verify the new set
-              (:sections db-company) => new-set
-              (:update db-company) => (contains r/text-section-1)
-              (:finances db-company) => (contains r/finances-section-1)
-              (:team db-company) => nil
-              (:help db-company) => (contains r/text-section-1)
-              (:diversity db-company) => (contains r/text-section-2)
-              (:values db-company) => (contains r/text-section-1)))
-
-          (fact "multiple sections can be removed from the progress category"
-            (let [new-set {:company ["help" "diversity" "values"]
-                           :progress []
-                           :financial ["finances"]}
-                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
-                  body (mock/body-from-response response)
-                  db-company (company/get-company conn r/slug)]
-              (:status response) => 200
-              (:sections body) => new-set
-              (:update body) => nil
-              (:team body) => nil
-              (:finances body) => (contains r/finances-section-1)
-              (:help body) => (contains r/text-section-1)
-              (:diversity body) => (contains r/text-section-2)
-              (:values body) => (contains r/text-section-1)
-              ;; verify the new set
-              (:sections db-company) => new-set
-              (:update db-company) => nil
-              (:team db-company) => nil
-              (:finances db-company) => (contains r/finances-section-1)
-              (:help db-company) => (contains r/text-section-1)
-              (:diversity db-company) => (contains r/text-section-2)
-              (:values db-company) => (contains r/text-section-1)))
-
-          (fact "a section can be removed from the company category"
-            (let [new-order {:company ["help" "diversity"]
-                             :progress ["update" "team"]
-                             :financial ["finances"]}
-                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-                  body (mock/body-from-response response)
-                  db-company (company/get-company conn r/slug)]
-              (:status response) => 200
-              (:sections body) => new-order
-              (:update body) => (contains r/text-section-1)
-              (:finances body) => (contains r/finances-section-1)
-              (:team body) => (contains r/text-section-2)
-              (:help body) => (contains r/text-section-1)
-              (:diversity body) => (contains r/text-section-2)
-              (:values body) => nil
-              ;; verify the new set
-              (:sections db-company) => new-order
-              (:update db-company) => (contains r/text-section-1)
-              (:finances db-company) => (contains r/finances-section-1)
-              (:team db-company) => (contains r/text-section-2)
-              (:help db-company) => (contains r/text-section-1)
-              (:diversity db-company) => (contains r/text-section-2)
-              (:values db-company) => nil))
-
-          (fact "sections can be removed from all the categories at once"
-            (let [new-order {:company ["values"]
-                             :progress ["update" "help"]
-                             :financial []}
-                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-                  body (mock/body-from-response response)
-                  db-company (company/get-company conn r/slug)]
-              (:status response) => 200
-              (:sections body) => new-order
-              (:update body) => (contains r/text-section-1)
-              (:finances body) => nil
-              (:team body) => nil
-              (:help body) => (contains r/text-section-1)
-              (:diversity body) => nil
-              (:values body) => (contains r/text-section-1)
-              ;; verify the new set
-              (:sections db-company) => new-order
-              (:update db-company) => (contains r/text-section-1)
-              (:finances db-company) => nil
-              (:team db-company) => nil
-              (:help db-company) => (contains r/text-section-1)
-              (:diversity db-company) => nil
-              (:values db-company) => (contains r/text-section-1))))
-        
-        (facts "about adding sections"
-
-          (fact "that don't really exist"
-            (let [new-sections {:company [] :progress ["health"] :financial []}
+        (facts "without any section content"
+          
+          (fact "that never existed"
+            (let [new-sections {:company [] :progress ["highlights"] :financial []}
                   response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                  body (mock/body-from-response response)]
-              (:status response) => 422))
+                  body (mock/body-from-response response)
+                  resp-highlights (:highlights body)
+                  db-company (company/get-company conn r/slug)
+                  db-highlights (:highlights db-company)
+                  placeholder (dissoc (common-res/section-by-name :highlights) :section-name :core)]
+              (:status response) => 200
+              (:sections body) => new-sections
+                                      ; verify placeholder flag and content in response
+              (:placeholder resp-highlights) => true 
+              resp-highlights => (contains placeholder)
+                                      ; verify placeholder flag and content in DB
+              (:placeholder db-highlights) => true
+              db-highlights => (contains placeholder)))
 
-          (facts "without any section content"
-            
-            (fact "that never existed"
-              (let [new-sections {:company [] :progress ["highlights"] :financial []}
-                    response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-                    body (mock/body-from-response response)
-                    resp-highlights (:highlights body)
-                    db-company (company/get-company conn r/slug)
-                    db-highlights (:highlights db-company)
-                    placeholder (dissoc (common-res/section-by-name :highlights) :section-name :core)]
-                (:status response) => 200
-                (:sections body) => new-sections
-                                        ; verify placeholder flag and content in response
-                (:placeholder resp-highlights) => true 
-                resp-highlights => (contains placeholder)
-                                        ; verify placeholder flag and content in DB
-                (:placeholder db-highlights) => true
-                db-highlights => (contains placeholder)))
+          (future-fact "that used to exist"
+                       (let [new-sections {:company [] :progress [] :financial []}
+                             response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                             body (mock/body-from-response response)
+                             db-company (company/get-company conn r/slug)]
+                         (:status response) => 200
+                         (:sections body) => new-sections
+                                      ; verify update is not in the response
+                         (:update body) => nil
+                                      ; verify update not in the DB
+                         (:update db-company) => nil)
+                       (let [new-sections {:company [] :progress ["update"] :financial []}
+                             response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                             body (mock/body-from-response response)
+                             db-company (company/get-company conn r/slug)]
+                         (:status response) => 200
+                         (:sections body) => new-sections
+                                      ; verify update is not in the response
+                         (:update body) => (contains r/text-section-1)
+                                      ; verify update not in the DB
+                         (:update db-company) => (contains r/text-section-1))))
 
-            (future-fact "that used to exist"
-                         (let [new-sections {:company [] :progress [] :financial []}
-                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+        (facts "with section content"
+
+          (let [new-sections {:company ["help" "diversity" "values"]
+                              :progress ["update" "team" "kudos"]
+                              :financial ["finances"]}
+                kudos-placeholder (common-res/section-by-name "kudos")]
+
+            (future-fact "with minimal content"
+                         (let [kudos-content {:body "Fred is killing it"}
+                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                                  :kudos kudos-content}})
                                body (mock/body-from-response response)
                                db-company (company/get-company conn r/slug)]
                            (:status response) => 200
-                           (:sections body) => new-sections
-                                        ; verify update is not in the response
-                           (:update body) => nil
-                                        ; verify update not in the DB
-                           (:update db-company) => nil)
-                         (let [new-sections {:company [] :progress ["update"] :financial []}
-                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                           (:body response) => nil))
+
+            (future-fact "with maximal content"
+                         (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
+                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                                  :kudos kudos-content}})
                                body (mock/body-from-response response)
                                db-company (company/get-company conn r/slug)]
                            (:status response) => 200
-                           (:sections body) => new-sections
-                                        ; verify update is not in the response
-                           (:update body) => (contains r/text-section-1)
-                                        ; verify update not in the DB
-                           (:update db-company) => (contains r/text-section-1))))
+                           (:body response) => nil))
 
-          (facts "with section content"
+            (future-fact "with too much content"
+                         
+                         (future-fact "extra properties aren't allowed")
 
-            (let [new-sections {:company ["help" "diversity" "values"]
-                                :progress ["update" "team" "kudos"]
-                                :financial ["finances"]}
-                  kudos-placeholder (common-res/section-by-name "kudos")]
-
-              (future-fact "with minimal content"
-                           (let [kudos-content {:body "Fred is killing it"}
-                                 response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                                    :kudos kudos-content}})
-                                 body (mock/body-from-response response)
-                                 db-company (company/get-company conn r/slug)]
-                             (:status response) => 200
-                             (:body response) => nil))
-
-              (future-fact "with maximal content"
-                           (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
-                                 response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                                    :kudos kudos-content}})
-                                 body (mock/body-from-response response)
-                                 db-company (company/get-company conn r/slug)]
-                             (:status response) => 200
-                             (:body response) => nil))
-
-              (future-fact "with too much content"
-                           
-                           (future-fact "extra properties aren't allowed")
-
-                           (future-fact "read/only properties are ignored")))))))))
+                         (future-fact "read/only properties are ignored")))))))))

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -56,327 +56,328 @@
                                      (company/delete-all-companies! conn)))]
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
 
-  (facts "about failing to reorder sections"
+    (facts "about failing to reorder sections"
 
-    (fact "with an invalid JWToken"
-      (let [new-order {:progress ["team" "update" "finances" "help"]
-                       :company ["diversity" "values"]}
-            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
-                                                                        :auth mock/jwtoken-bad})]
-        (:status response) => 401
-        (:body response) => common/unauthorized)
-      ;; verify the initial order is unchanged
-      (let [db-company (company/get-company r/slug)]
-        (:categories db-company) => categories
-        (:sections db-company) => {:company ["help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]}))
-
-    (fact "with no JWToken"
-      (let [new-order {:progress ["team" "update" "finances" "help"]
-                       :company ["diversity" "values"]}
-            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
-                                                                        :skip-auth true})]
-        (:status response) => 401
-        (:body response) => common/unauthorized)
-      ;; verify the initial order is unchanged
-      (let [db-company (company/get-company r/slug)]
-        (:categories db-company) => categories
-        (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]}))
-
-    (fact "with an organization that doesn't match the company"
-      (let [new-order {:progress ["team" "update" "finances" "help"]
-                       :company ["diversity" "values"]}
-            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
-                                                                        :auth mock/jwtoken-sartre})]
-        (:status response) => 403
-        (:body response) => common/forbidden)
-      ;; verify the initial order is unchanged
-      (let [db-company (company/get-company r/slug)]
-        (:categories db-company) => categories
-        (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]}))
-
-    (fact "with no company matching the company slug"
-      (let [new-order {:company ["diversity" "values"]
-                       :progress ["team" "update" "finances" "help"]
-                       :financial []}
-            response (mock/api-request :patch (company-rep/url "foo") {:body {:sections new-order}})]
-        (:status response) => 404
-        (:body response) => "")
-      ;; verify the initial order is unchanged
-      (let [db-company (company/get-company r/slug)]
-        (:categories db-company) => categories
-        (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]})))
-
-  (facts "about section reordering"
-
-    ;; verify the initial order
-    (let [db-company (company/get-company r/slug)]
-      (:categories db-company) => categories
-      (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                 :progress ["update" "team"]
-                                 :financial ["finances"]})
-
-    (facts "when the new order is valid"
-
-      (fact "the section order in the progress category can be gently adjusted"
-        (let [new-order {:progress ["team" "update" "help"]
-                         :financial ["finances"]
+      (fact "with an invalid JWToken"
+        (let [new-order {:progress ["team" "update" "finances" "help"]
                          :company ["diversity" "values"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
-          (:status response) => 200
-          (:sections (mock/body-from-response response)) => new-order
-          ;; verify the new order
-          (:sections (company/get-company r/slug)) => new-order))
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
+                                                                          :auth mock/jwtoken-bad})]
+          (:status response) => 401
+          (:body response) => common/unauthorized)
+        ;; verify the initial order is unchanged
+        (let [db-company (company/get-company conn r/slug)]
+          (:categories db-company) => categories
+          (:sections db-company) => {:company ["help" "diversity" "values"]
+                                     :progress ["update" "team"]
+                                     :financial ["finances"]}))
 
-      (fact "the sections order in the progress category can be greatly adjusted"
-        (let [new-order {:progress ["help" "team" "update"]
-                         :financial ["finances"]
+      (fact "with no JWToken"
+        (let [new-order {:progress ["team" "update" "finances" "help"]
                          :company ["diversity" "values"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
-          (:status response) => 200
-          (:sections (mock/body-from-response response)) => new-order
-          ;; verify the new order
-          (:sections (company/get-company r/slug)) => new-order))
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
+                                                                          :skip-auth true})]
+          (:status response) => 401
+          (:body response) => common/unauthorized)
+        ;; verify the initial order is unchanged
+        (let [db-company (company/get-company conn r/slug)]
+          (:categories db-company) => categories
+          (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                     :progress ["update" "team"]
+                                     :financial ["finances"]}))
 
-      (fact "the section order in the company category can be adjusted"
-        (let [new-order {:progress ["update" "team" "help"]
-                         :financial ["finances"]
-                         :company ["values" "diversity"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
-          (:status response) => 200
-          (:sections (mock/body-from-response response)) => new-order
-          ;; verify the new order
-          (:sections (company/get-company r/slug)) => new-order))
+      (fact "with an organization that doesn't match the company"
+        (let [new-order {:progress ["team" "update" "finances" "help"]
+                         :company ["diversity" "values"]}
+              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}
+                                                                          :auth mock/jwtoken-sartre})]
+          (:status response) => 403
+          (:body response) => common/forbidden)
+        ;; verify the initial order is unchanged
+        (let [db-company (company/get-company conn r/slug)]
+          (:categories db-company) => categories
+          (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                     :progress ["update" "team"]
+                                     :financial ["finances"]}))
 
-      (fact "the section order in the progress and company category can both be adjusted at once"
-        (let [new-order {:progress ["help" "team" "update"]
-                         :financial ["finances"]
-                         :company ["values" "diversity"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
-          (:status response) => 200
-          (:sections company) => new-set
-          (:growth company) => falsey
-          (:challenges company) => falsey
-          (:team company) => falsey
-          (:product company) => falsey
-          (:mission company) => falsey)))
-
-    (facts "about section removal"
-
-  (facts "about placeholder section removal"
-    (let [slug     "hello-world"
-          payload  {:name "Hello World" :description "x"}
-          response (mock/api-request :post "/companies" {:body payload})
-          company  (company/get-company conn slug)]
-      ;; ensure all placeholder sections are in company
-      (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
-                              :financial ["finances"]
-                              :company ["mission" "values"]}
-      (:growth company) => truthy
-      (:challenges company) => truthy
-      (:team company) => truthy
-      (:product company) => truthy
-      (:mission company) => truthy
-      (let [new-set {:company ["values"]
-                     :progress ["update" "finances" "help"]
-                     :financial []}
-            response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
-            body     (mock/body-from-response response)
-            company  (company/get-company conn slug)]
-        (:status response) => 200
-        (:sections company) => new-set
-        (:growth company) => falsey
-        (:challenges company) => falsey
-        (:team company) => falsey
-        (:product company) => falsey
-        (:mission company) => falsey)))
-
-  (facts "about section removal"
-
-    ;; verify the initial set of sections
-    (:sections (company/get-company conn r/slug)) => {:company ["help" "diversity" "values"]
-                                                 :progress ["update" "team"]
-                                                 :financial ["finances"]}
-
-      (fact "a section can be removed from the progress category"
-        (let [new-set {:company ["help" "diversity" "values"]
-                       :progress ["update"]
-                       :financial ["finances"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
-              body (mock/body-from-response response)
-              db-company (company/get-company conn r/slug)]
-          (:status response) => 200
-          (:sections body) => new-set
-          (:update body) => (contains r/text-section-1)
-          (:finances body) => (contains r/finances-section-1)
-          (:team body) => nil
-          (:help body) => (contains r/text-section-1)
-          (:diversity body) => (contains r/text-section-2)
-          (:values body) => (contains r/text-section-1)
-          ;; verify the new set
-          (:sections db-company) => new-set
-          (:update db-company) => (contains r/text-section-1)
-          (:finances db-company) => (contains r/finances-section-1)
-          (:team db-company) => nil
-          (:help db-company) => (contains r/text-section-1)
-          (:diversity db-company) => (contains r/text-section-2)
-          (:values db-company) => (contains r/text-section-1)))
-
-      (fact "multiple sections can be removed from the progress category"
-        (let [new-set {:company ["help" "diversity" "values"]
-                       :progress []
-                       :financial ["finances"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
-              body (mock/body-from-response response)
-              db-company (company/get-company conn r/slug)]
-          (:status response) => 200
-          (:sections body) => new-set
-          (:update body) => nil
-          (:team body) => nil
-          (:finances body) => (contains r/finances-section-1)
-          (:help body) => (contains r/text-section-1)
-          (:diversity body) => (contains r/text-section-2)
-          (:values body) => (contains r/text-section-1)
-          ;; verify the new set
-          (:sections db-company) => new-set
-          (:update db-company) => nil
-          (:team db-company) => nil
-          (:finances db-company) => (contains r/finances-section-1)
-          (:help db-company) => (contains r/text-section-1)
-          (:diversity db-company) => (contains r/text-section-2)
-          (:values db-company) => (contains r/text-section-1)))
-
-      (fact "a section can be removed from the company category"
-        (let [new-order {:company ["help" "diversity"]
-                         :progress ["update" "team"]
-                         :financial ["finances"]}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-              body (mock/body-from-response response)
-              db-company (company/get-company conn r/slug)]
-          (:status response) => 200
-          (:sections body) => new-order
-          (:update body) => (contains r/text-section-1)
-          (:finances body) => (contains r/finances-section-1)
-          (:team body) => (contains r/text-section-2)
-          (:help body) => (contains r/text-section-1)
-          (:diversity body) => (contains r/text-section-2)
-          (:values body) => nil
-          ;; verify the new set
-          (:sections db-company) => new-order
-          (:update db-company) => (contains r/text-section-1)
-          (:finances db-company) => (contains r/finances-section-1)
-          (:team db-company) => (contains r/text-section-2)
-          (:help db-company) => (contains r/text-section-1)
-          (:diversity db-company) => (contains r/text-section-2)
-          (:values db-company) => nil))
-
-      (fact "sections can be removed from all the categories at once"
-        (let [new-order {:company ["values"]
-                         :progress ["update" "help"]
+      (fact "with no company matching the company slug"
+        (let [new-order {:company ["diversity" "values"]
+                         :progress ["team" "update" "finances" "help"]
                          :financial []}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
-              body (mock/body-from-response response)
-              db-company (company/get-company conn r/slug)]
-          (:status response) => 200
-          (:sections body) => new-order
-          (:update body) => (contains r/text-section-1)
-          (:finances body) => nil
-          (:team body) => nil
-          (:help body) => (contains r/text-section-1)
-          (:diversity body) => nil
-          (:values body) => (contains r/text-section-1)
-          ;; verify the new set
-          (:sections db-company) => new-order
-          (:update db-company) => (contains r/text-section-1)
-          (:finances db-company) => nil
-          (:team db-company) => nil
-          (:help db-company) => (contains r/text-section-1)
-          (:diversity db-company) => nil
-          (:values db-company) => (contains r/text-section-1))))
-  
-  (facts "about adding sections"
+              response (mock/api-request :patch (company-rep/url "foo") {:body {:sections new-order}})]
+          (:status response) => 404
+          (:body response) => "")
+        ;; verify the initial order is unchanged
+        (let [db-company (company/get-company conn r/slug)]
+          (:categories db-company) => categories
+          (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                     :progress ["update" "team"]
+                                     :financial ["finances"]})))
 
-    (fact "that don't really exist"
-      (let [new-sections {:company [] :progress ["health"] :financial []}
-            response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-            body (mock/body-from-response response)]
-        (:status response) => 422))
+    (facts "about section reordering"
 
-    (facts "without any section content"
-    
-      (fact "that never existed"
-        (let [new-sections {:company [] :progress ["highlights"] :financial []}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-              body (mock/body-from-response response)
-              resp-highlights (:highlights body)
-              db-company (company/get-company r/slug)
-              db-highlights (:highlights db-company)
-              placeholder (dissoc (common-res/section-by-name :highlights) :section-name :core)]
-          (:status response) => 200
-          (:sections body) => new-sections
-          ; verify placeholder flag and content in response
-          (:placeholder resp-highlights) => true 
-          resp-highlights => (contains placeholder)
-          ; verify placeholder flag and content in DB
-          (:placeholder db-highlights) => true
-          db-highlights => (contains placeholder)))
+      ;; verify the initial order
+      (let [db-company (company/get-company conn r/slug)]
+        (:categories db-company) => categories
+        (:sections db-company) => {:company [ "help" "diversity" "values"]
+                                   :progress ["update" "team"]
+                                   :financial ["finances"]})
 
-      (future-fact "that used to exist"
-        (let [new-sections {:company [] :progress [] :financial []}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-              body (mock/body-from-response response)
-              db-company (company/get-company r/slug)]
-          (:status response) => 200
-          (:sections body) => new-sections
-          ; verify update is not in the response
-          (:update body) => nil
-          ; verify update not in the DB
-          (:update db-company) => nil)
-        (let [new-sections {:company [] :progress ["update"] :financial []}
-              response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
-              body (mock/body-from-response response)
-              db-company (company/get-company r/slug)]
-          (:status response) => 200
-          (:sections body) => new-sections
-          ; verify update is not in the response
-          (:update body) => (contains r/text-section-1)
-          ; verify update not in the DB
-          (:update db-company) => (contains r/text-section-1))))
+      (facts "when the new order is valid"
 
-    (facts "with section content"
-
-      (let [new-sections {:company ["help" "diversity" "values"]
-                            :progress ["update" "team" "kudos"]
-                            :financial ["finances"]}
-            kudos-placeholder (common-res/section-by-name "kudos")]
-
-        (future-fact "with minimal content"
-          (let [kudos-content {:body "Fred is killing it"}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                 :kudos kudos-content}})
-                body (mock/body-from-response response)
-                db-company (company/get-company r/slug)]
+        (fact "the section order in the progress category can be gently adjusted"
+          (let [new-order {:progress ["team" "update" "help"]
+                           :financial ["finances"]
+                           :company ["diversity" "values"]}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
             (:status response) => 200
-            (:body response) => nil))
+            (:sections (mock/body-from-response response)) => new-order
+            ;; verify the new order
+            (:sections (company/get-company conn r/slug)) => new-order))
 
-        (future-fact "with maximal content"
-          (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
-                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
-                                                                                   :kudos kudos-content}})
-                body (mock/body-from-response response)
-                db-company (company/get-company r/slug)]
+        (fact "the sections order in the progress category can be greatly adjusted"
+          (let [new-order {:progress ["help" "team" "update"]
+                           :financial ["finances"]
+                           :company ["diversity" "values"]}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
             (:status response) => 200
-            (:body response) => nil))
+            (:sections (mock/body-from-response response)) => new-order
+            ;; verify the new order
+            (:sections (company/get-company conn r/slug)) => new-order))
 
-        (future-fact "with too much content"
-      
-          (future-fact "extra properties aren't allowed")
+        (fact "the section order in the company category can be adjusted"
+          (let [new-order {:progress ["update" "team" "help"]
+                           :financial ["finances"]
+                           :company ["values" "diversity"]}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
+            (:status response) => 200
+            (:sections (mock/body-from-response response)) => new-order
+            ;; verify the new order
+            (:sections (company/get-company conn r/slug)) => new-order))
 
-          (future-fact "read/only properties are ignored")))))))))
+        (fact "the section order in the progress and company category can both be adjusted at once"
+          (let [new-order {:progress ["help" "update"]
+                           :financial ["finances"]
+                           :company ["values" "diversity"]}
+                response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+                company  (company/get-company conn r/slug)]
+            (:status response) => 200
+            (:sections company) => new-order
+            (:growth company) => falsey
+            (:challenges company) => falsey
+            (:team company) => falsey
+            (:product company) => falsey
+            (:mission company) => falsey)))
+
+      (facts "about section removal"
+
+        (facts "about placeholder section removal"
+          (let [slug     "hello-world"
+                payload  {:name "Hello World" :description "x" :slug slug}
+                response (mock/api-request :post "/companies" {:body payload})
+                company  (company/get-company conn slug)]
+            ;; ensure all placeholder sections are in company
+            (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
+                                    :financial ["finances"]
+                                    :company ["mission" "values"]}
+            (:growth company) => truthy
+            (:challenges company) => truthy
+            (:team company) => truthy
+            (:product company) => truthy
+            (:mission company) => truthy
+            (let [new-set {:company ["values"]
+                           :progress ["update" "finances" "help"]
+                           :financial []}
+                  response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
+                  body     (mock/body-from-response response)
+                  company  (company/get-company conn slug)]
+              (:status response) => 200
+              (:sections company) => new-set
+              (:growth company) => falsey
+              (:challenges company) => falsey
+              (:team company) => falsey
+              (:product company) => falsey
+              (:mission company) => falsey)))
+
+        (facts "about section removal"
+
+          ;; verify the initial set of sections
+          (:sections (company/get-company conn r/slug)) => {:company ["help" "diversity" "values"]
+                                                            :progress ["update" "team"]
+                                                            :financial ["finances"]}
+
+          (fact "a section can be removed from the progress category"
+            (let [new-set {:company ["help" "diversity" "values"]
+                           :progress ["update"]
+                           :financial ["finances"]}
+                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+                  body (mock/body-from-response response)
+                  db-company (company/get-company conn r/slug)]
+              (:status response) => 200
+              (:sections body) => new-set
+              (:update body) => (contains r/text-section-1)
+              (:finances body) => (contains r/finances-section-1)
+              (:team body) => nil
+              (:help body) => (contains r/text-section-1)
+              (:diversity body) => (contains r/text-section-2)
+              (:values body) => (contains r/text-section-1)
+              ;; verify the new set
+              (:sections db-company) => new-set
+              (:update db-company) => (contains r/text-section-1)
+              (:finances db-company) => (contains r/finances-section-1)
+              (:team db-company) => nil
+              (:help db-company) => (contains r/text-section-1)
+              (:diversity db-company) => (contains r/text-section-2)
+              (:values db-company) => (contains r/text-section-1)))
+
+          (fact "multiple sections can be removed from the progress category"
+            (let [new-set {:company ["help" "diversity" "values"]
+                           :progress []
+                           :financial ["finances"]}
+                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
+                  body (mock/body-from-response response)
+                  db-company (company/get-company conn r/slug)]
+              (:status response) => 200
+              (:sections body) => new-set
+              (:update body) => nil
+              (:team body) => nil
+              (:finances body) => (contains r/finances-section-1)
+              (:help body) => (contains r/text-section-1)
+              (:diversity body) => (contains r/text-section-2)
+              (:values body) => (contains r/text-section-1)
+              ;; verify the new set
+              (:sections db-company) => new-set
+              (:update db-company) => nil
+              (:team db-company) => nil
+              (:finances db-company) => (contains r/finances-section-1)
+              (:help db-company) => (contains r/text-section-1)
+              (:diversity db-company) => (contains r/text-section-2)
+              (:values db-company) => (contains r/text-section-1)))
+
+          (fact "a section can be removed from the company category"
+            (let [new-order {:company ["help" "diversity"]
+                             :progress ["update" "team"]
+                             :financial ["finances"]}
+                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+                  body (mock/body-from-response response)
+                  db-company (company/get-company conn r/slug)]
+              (:status response) => 200
+              (:sections body) => new-order
+              (:update body) => (contains r/text-section-1)
+              (:finances body) => (contains r/finances-section-1)
+              (:team body) => (contains r/text-section-2)
+              (:help body) => (contains r/text-section-1)
+              (:diversity body) => (contains r/text-section-2)
+              (:values body) => nil
+              ;; verify the new set
+              (:sections db-company) => new-order
+              (:update db-company) => (contains r/text-section-1)
+              (:finances db-company) => (contains r/finances-section-1)
+              (:team db-company) => (contains r/text-section-2)
+              (:help db-company) => (contains r/text-section-1)
+              (:diversity db-company) => (contains r/text-section-2)
+              (:values db-company) => nil))
+
+          (fact "sections can be removed from all the categories at once"
+            (let [new-order {:company ["values"]
+                             :progress ["update" "help"]
+                             :financial []}
+                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
+                  body (mock/body-from-response response)
+                  db-company (company/get-company conn r/slug)]
+              (:status response) => 200
+              (:sections body) => new-order
+              (:update body) => (contains r/text-section-1)
+              (:finances body) => nil
+              (:team body) => nil
+              (:help body) => (contains r/text-section-1)
+              (:diversity body) => nil
+              (:values body) => (contains r/text-section-1)
+              ;; verify the new set
+              (:sections db-company) => new-order
+              (:update db-company) => (contains r/text-section-1)
+              (:finances db-company) => nil
+              (:team db-company) => nil
+              (:help db-company) => (contains r/text-section-1)
+              (:diversity db-company) => nil
+              (:values db-company) => (contains r/text-section-1))))
+        
+        (facts "about adding sections"
+
+          (fact "that don't really exist"
+            (let [new-sections {:company [] :progress ["health"] :financial []}
+                  response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                  body (mock/body-from-response response)]
+              (:status response) => 422))
+
+          (facts "without any section content"
+            
+            (fact "that never existed"
+              (let [new-sections {:company [] :progress ["highlights"] :financial []}
+                    response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                    body (mock/body-from-response response)
+                    resp-highlights (:highlights body)
+                    db-company (company/get-company conn r/slug)
+                    db-highlights (:highlights db-company)
+                    placeholder (dissoc (common-res/section-by-name :highlights) :section-name :core)]
+                (:status response) => 200
+                (:sections body) => new-sections
+                                        ; verify placeholder flag and content in response
+                (:placeholder resp-highlights) => true 
+                resp-highlights => (contains placeholder)
+                                        ; verify placeholder flag and content in DB
+                (:placeholder db-highlights) => true
+                db-highlights => (contains placeholder)))
+
+            (future-fact "that used to exist"
+                         (let [new-sections {:company [] :progress [] :financial []}
+                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                               body (mock/body-from-response response)
+                               db-company (company/get-company conn r/slug)]
+                           (:status response) => 200
+                           (:sections body) => new-sections
+                                        ; verify update is not in the response
+                           (:update body) => nil
+                                        ; verify update not in the DB
+                           (:update db-company) => nil)
+                         (let [new-sections {:company [] :progress ["update"] :financial []}
+                               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
+                               body (mock/body-from-response response)
+                               db-company (company/get-company conn r/slug)]
+                           (:status response) => 200
+                           (:sections body) => new-sections
+                                        ; verify update is not in the response
+                           (:update body) => (contains r/text-section-1)
+                                        ; verify update not in the DB
+                           (:update db-company) => (contains r/text-section-1))))
+
+          (facts "with section content"
+
+            (let [new-sections {:company ["help" "diversity" "values"]
+                                :progress ["update" "team" "kudos"]
+                                :financial ["finances"]}
+                  kudos-placeholder (common-res/section-by-name "kudos")]
+
+              (future-fact "with minimal content"
+                           (let [kudos-content {:body "Fred is killing it"}
+                                 response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                                    :kudos kudos-content}})
+                                 body (mock/body-from-response response)
+                                 db-company (company/get-company conn r/slug)]
+                             (:status response) => 200
+                             (:body response) => nil))
+
+              (future-fact "with maximal content"
+                           (let [kudos-content {:title "Great Jobs!" :headline "Good stuff" :body "Fred is killing it"}
+                                 response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections
+                                                                                                    :kudos kudos-content}})
+                                 body (mock/body-from-response response)
+                                 db-company (company/get-company conn r/slug)]
+                             (:status response) => 200
+                             (:body response) => nil))
+
+              (future-fact "with too much content"
+                           
+                           (future-fact "extra properties aren't allowed")
+
+                           (future-fact "read/only properties are ignored")))))))))

--- a/test/open_company/integration/section/section_revision.clj
+++ b/test/open_company/integration/section/section_revision.clj
@@ -5,8 +5,8 @@
             [open-company.lib.rest-api-mock :as mock]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
-            [open-company.lib.test-setup :as ts]
             [open-company.db.pool :as pool]
+            [open-company.lib.test-setup :as ts]
             [open-company.api.common :as common]
             [open-company.resources.company :as c]
             [open-company.resources.section :as s]
@@ -63,14 +63,14 @@
 (def limited-options "OPTIONS, GET")
 (def full-options "OPTIONS, GET, PUT, PATCH")
 
-(with-state-changes [(before :contents (ts/setup-system!))
+(with-state-changes [(around :facts (schema.core/with-fn-validation ?form))
+                     (before :contents (ts/setup-system!))
                      (after :contents (ts/teardown-system!))
-                     (around :facts (schema.core/with-fn-validation ?form))
                      (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
-                                      (c/delete-company conn r/slug)
+                                      (c/delete-all-companies! conn)
                                       (c/create-company! conn (c/->company r/open r/coyote))))
                      (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
-                                     (c/delete-company conn r/slug)))]
+                                     (c/delete-all-companies! conn)))]
 
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
     (with-state-changes [(before :facts (s/put-section conn r/slug :update r/text-section-1 r/coyote))]
@@ -90,193 +90,6 @@
         (fact "with no section matching the section name"
           (let [response (mock/api-request :options (section-rep/url r/slug :diversity))]
             (:status response) => 404
-<<<<<<< d3ab26991d01cd84e6a745774dcd70ad92009ff4
-            (:body response) => "")
-          ;; verify the initial section is unchanged
-          (s/get-section r/slug :update) => (contains r/text-section-1)
-          (count (s/get-revisions r/slug :update)) => 1))))
-
-  (facts "about updating an existing section revision"
-
-    (facts "with PUT"
-
-      (with-state-changes [(before :facts (s/put-section r/slug :update r/text-section-1 r/coyote))]
-
-        (fact "update existing revision title"
-          (let [updated (assoc r/text-section-1 :title "New Title")
-                response (mock/api-request :put (section-rep/url r/slug :update) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)]
-            (:status response) => 200
-            body => (contains updated)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :update)]
-              updated-section => (contains updated)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :update)) => 1)) ; but there is still just 1 revision
-
-        (fact "update existing revision body"
-          (let [updated (assoc r/text-section-1 :body "New Body")
-                response (mock/api-request :put (section-rep/url r/slug :update) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)]
-            (:status response) => 200
-            body => (contains updated)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :update)]
-              updated-section => (contains updated)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :update)) => 1))) ; but there is still just 1 revision
-
-      (with-state-changes [(before :facts (s/put-section r/slug :finances r/finances-section-1 r/coyote))]
-
-        (fact "update existing revision note"
-          (let [updated (assoc r/text-section-1 :note "New Note")
-                response (mock/api-request :put (section-rep/url r/slug :finances) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)]
-            (:status response) => 200
-            body => (contains updated)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :finances)]
-              updated-section => (contains updated)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :finances)) => 1)) ; but there is still just 1 revision
-
-        (fact "update existing revision title, body and note"
-          (let [updated {:body "New Body" :title "New Title" :note "New Note"}
-                response (mock/api-request :put (section-rep/url r/slug :finances) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)]
-            (:status response) => 200
-            body => (contains updated)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :finances)]
-              updated-section => (contains updated)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :finances)) => 1)))) ; but there is still just 1 revision
-
-    (facts "with PATCH"
-
-      (with-state-changes [(before :facts (s/put-section r/slug :update r/text-section-1 r/coyote))]
-
-        (fact "update existing revision title"
-          (let [updated {:title "New Title"}
-                response (mock/api-request :patch (section-rep/url r/slug :update) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)
-                updated-section (merge r/text-section-1 updated)]
-            (:status response) => 200
-            body => (contains updated-section)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :update)]
-              updated-section => (contains updated-section)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :update)) => 1)) ; but there is still just 1 revision
-
-        (fact "update existing revision body"
-          (let [updated {:body "New Body"}
-                response (mock/api-request :patch (section-rep/url r/slug :update) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)
-                updated-section (merge r/text-section-1 updated)]
-            (:status response) => 200
-            body => (contains updated-section)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :update)]
-              updated-section => (contains updated-section)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :update)) => 1))) ; but there is still just 1 revision
-
-      (with-state-changes [(before :facts (s/put-section r/slug :finances r/finances-section-1 r/coyote))]
-
-        (fact "update existing revision note"
-          (let [updated {:note "New Note"}
-                response (mock/api-request :patch (section-rep/url r/slug :finances) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)
-                updated-section (merge r/finances-section-1 updated)]
-            (:status response) => 200
-            body => (contains updated-section)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :finances)]
-              updated-section => (contains updated-section)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :finances)) => 1)) ; but there is still just 1 revision
-
-        (fact "update existing revision title, body and note"
-          (let [updated {:body "New Body" :title "New Title" :note "New Note"}
-                response (mock/api-request :patch (section-rep/url r/slug :finances) {:body updated})
-                body (mock/body-from-response response)
-                updated-at (:updated-at body)]
-            (:status response) => 200
-            body => (contains updated)
-            ;; verify the initial revision is changed
-            (let [updated-section (s/get-section r/slug :finances)]
-              updated-section => (contains updated)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? (:created-at updated-section) updated-at) => true)
-            (count (s/get-revisions r/slug :finances)) => 1))))) ; but there is still just 1 revision
-
-  (facts "about updating a placeholder section"
-
-    (facts "with PUT"
-      (with-state-changes [(before :facts (c/create-company! (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
-                           (after :facts (c/delete-company (:slug r/buffer)))]
-        (fact "update existing revision title"
-          (let [updated  (assoc r/text-section-1 :title "New Title")
-                response (mock/api-request :put (section-rep/url (:slug r/buffer) :update) {:body updated})
-                body     (mock/body-from-response response)
-                company  (c/get-company (:slug r/buffer))]
-            (:status response) => 200
-            (-> company :update :placeholder) => falsey
-            body => (contains updated)
-            (:placeholder body) => falsey))))
-
-    (facts "with PATCH"
-      (with-state-changes [(before :facts (c/create-company! (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
-                           (after :facts (c/delete-company (:slug r/buffer)))]
-        (fact "update existing revision title"
-          (let [updated  {:title "New Title"}
-                response (mock/api-request :patch (section-rep/url (:slug r/buffer) :update) {:body updated})
-                body     (mock/body-from-response response)
-                company  (c/get-company (:slug r/buffer))]
-            (:status response) => 200
-            (-> company :update :placeholder) => falsey
-            (:title body) => (:title updated)
-            (:placeholder body) => falsey))))
-
-    (future-facts "with DELETE"
-      #_(with-state-changes [(before :facts (c/create-company! (c/->company r/buffer r/coyote)))
-                           (after :facts (c/delete-company (:slug r/buffer)))]
-        (fact "update existing revision title"
-          (let [response (mock/api-request :delete (section-rep/url (:slug r/buffer) :update))
-                body     (mock/body-from-response response)
-                company  (c/get-company (:slug r/buffer))]
-            (:status response) => 200
-            (-> company :update) => nil)))))
-
-  (future-facts "about creating a new section revision"
-
-    (future-facts "with PUT")
-
-    (future-facts "with PATCH")))
-=======
             (:body response) => ""))
 
         (fact "with no JWToken"
@@ -479,49 +292,46 @@
                 (check/timestamp? updated-at) => true
                 (check/about-now? updated-at) => true
                 (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :finances)) => 1)))) ; but there is still just 1 revision
+              (count (s/get-revisions conn r/slug :finances)) => 1))))) ; but there is still just 1 revision
 
-      (facts "about updating a placeholder section"
+    (facts "about updating a placeholder section"
 
-        (facts "with PUT"
-          (with-state-changes [(before :facts (c/create-company! conn (c/add-placeholder-sections (c/->company r/buffer r/coyote))))
-                               (after :facts (c/delete-company conn (:slug r/buffer)))]
-            (fact "update existing revision title"
-              (let [updated  (assoc r/text-section-1 :title "New Title")
-                    response (mock/api-request :put (section-rep/url (:slug r/buffer) :update) {:body updated})
-                    body     (mock/body-from-response response)
-                    company  (c/get-company conn (:slug r/buffer))]
-                (:status response) => 200
-                (-> company :update :placeholder) => falsey
-                body => (contains updated)
-                (:placeholder body) => falsey))))
+      (facts "with PUT"
+        (with-state-changes [(before :facts (c/create-company! conn (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
+                             (after :facts (c/delete-company conn (:slug r/buffer)))]
+          (fact "update existing revision title"
+            (let [updated  (assoc r/text-section-1 :title "New Title")
+                  response (mock/api-request :put (section-rep/url (:slug r/buffer) :update) {:body updated})
+                  body     (mock/body-from-response response)
+                  company  (c/get-company conn (:slug r/buffer))]
+              (:status response) => 200
+              (-> company :update :placeholder) => falsey
+              body => (contains updated)
+              (:placeholder body) => falsey))))
 
-        (facts "with PATCH"
-          (with-state-changes [(before :facts (c/create-company! conn (c/add-placeholder-sections (c/->company r/buffer r/coyote))))
-                               (after :facts (c/delete-company conn (:slug r/buffer)))]
-            (fact "update existing revision title"
-              (let [updated  {:title "New Title"}
-                    response (mock/api-request :patch (section-rep/url (:slug r/buffer) :update) {:body updated})
-                    body     (mock/body-from-response response)
-                    company  (c/get-company conn (:slug r/buffer))]
-                (:status response) => 200
-                (-> company :update :placeholder) => falsey
-                (:title body) => (:title updated)
-                (:placeholder body) => falsey))))
+      (facts "with PATCH"
+        (with-state-changes [(before :facts (c/create-company! conn (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
+                             (after :facts (c/delete-company conn (:slug r/buffer)))]
+          (fact "update existing revision title"
+            (let [updated  {:title "New Title"}
+                  response (mock/api-request :patch (section-rep/url (:slug r/buffer) :update) {:body updated})
+                  body     (mock/body-from-response response)
+                  company  (c/get-company conn (:slug r/buffer))]
+              (:status response) => 200
+              (-> company :update :placeholder) => falsey
+              (:title body) => (:title updated)
+              (:placeholder body) => falsey))))
 
-        (future-facts "with DELETE"
-                      #_(with-state-changes [(before :facts (c/create-company! conn (c/->company r/buffer r/coyote)))
-                                             (after :facts (c/delete-company conn (:slug r/buffer)))]
-                          (fact "update existing revision title"
-                            (let [response (mock/api-request :delete (section-rep/url (:slug r/buffer) :update))
-                                  body     (mock/body-from-response response)
-                                  company  (c/get-company conn (:slug r/buffer))]
-                              (:status response) => 200
-                              (-> company :update) => nil)))))
+      (future-facts "with DELETE"
+                    #_(with-state-changes [(before :facts (c/create-company! conn (c/->company r/buffer r/coyote)))
+                                           (after :facts (c/delete-company conn (:slug r/buffer)))]
+                        (fact "update existing revision title"
+                          (let [response (mock/api-request :delete (section-rep/url (:slug r/buffer) :update))
+                                body     (mock/body-from-response response)
+                                company  (c/get-company conn (:slug r/buffer))]
+                            (:status response) => 200
+                            (-> company :update) => nil)))))
 
-      (future-facts "about creating a new section revision"
-
-                    (future-facts "with PUT")
-
-                    (future-facts "with PATCH")))))
->>>>>>> provide testing setup & fix all tests
+    (future-facts "about creating a new section revision"
+                  (future-facts "with PUT")
+                  (future-facts "with PATCH"))))

--- a/test/open_company/integration/section/section_revision.clj
+++ b/test/open_company/integration/section/section_revision.clj
@@ -323,15 +323,15 @@
             (:placeholder body) => falsey))))
 
     (future-facts "with DELETE"
-                  #_(with-state-changes [(before :facts (c/create-company! conn (c/->company r/buffer r/coyote)))
-                                         (after :facts (c/delete-company conn (:slug r/buffer)))]
-                      (fact "update existing revision title"
-                        (let [response (mock/api-request :delete (section-rep/url (:slug r/buffer) :update))
-                              body     (mock/body-from-response response)
-                              company  (c/get-company conn (:slug r/buffer))]
-                          (:status response) => 200
-                          (-> company :update) => nil)))))
+      #_(with-state-changes [(before :facts (c/create-company! conn (c/->company r/buffer r/coyote)))
+                             (after :facts (c/delete-company conn (:slug r/buffer)))]
+          (fact "update existing revision title"
+            (let [response (mock/api-request :delete (section-rep/url (:slug r/buffer) :update))
+                  body     (mock/body-from-response response)
+                  company  (c/get-company conn (:slug r/buffer))]
+              (:status response) => 200
+              (-> company :update) => nil)))))
 
   (future-facts "about creating a new section revision"
-                (future-facts "with PUT")
-                (future-facts "with PATCH"))))
+    (future-facts "with PUT")
+    (future-facts "with PATCH"))))

--- a/test/open_company/integration/section/section_revision.clj
+++ b/test/open_company/integration/section/section_revision.clj
@@ -73,265 +73,265 @@
                                      (c/delete-all-companies! conn)))]
 
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
-    (with-state-changes [(before :facts (s/put-section conn r/slug :update r/text-section-1 r/coyote))]
+  (with-state-changes [(before :facts (s/put-section conn r/slug :update r/text-section-1 r/coyote))]
 
-      (facts "about available options for new section revisions"
+    (facts "about available options for new section revisions"
 
-        (fact "with a bad JWToken"
-          (let [response (mock/api-request :options (section-rep/url r/slug :update) {:auth mock/jwtoken-bad})]
+      (fact "with a bad JWToken"
+        (let [response (mock/api-request :options (section-rep/url r/slug :update) {:auth mock/jwtoken-bad})]
+          (:status response) => 401
+          (:body response) => common/unauthorized))
+
+      (fact "with no company matching the company slug"
+        (let [response (mock/api-request :options (section-rep/url "foo" :update))]
+          (:status response) => 404
+          (:body response) => ""))
+
+      (fact "with no section matching the section name"
+        (let [response (mock/api-request :options (section-rep/url r/slug :diversity))]
+          (:status response) => 404
+          (:body response) => ""))
+
+      (fact "with no JWToken"
+        (let [response (mock/api-request :options (section-rep/url r/slug :update) {:skip-auth true})]
+          (:status response) => 204
+          (:body response) => ""
+          ((:headers response) "Allow") => limited-options))
+
+      (fact "with an organization that doesn't match the company"
+        (let [response (mock/api-request :options (section-rep/url r/slug :update) {:auth mock/jwtoken-sartre})]
+          (:status response) => 204
+          (:body response) => ""
+          ((:headers response) "Allow") => limited-options))
+
+      (fact "with an organization that matches the company"
+        (let [response (mock/api-request :options (section-rep/url r/slug :update))]
+          (:status response) => 204
+          (:body response) => ""
+          ((:headers response) "Allow") => full-options)))
+
+    (facts "about failing to update a section"
+
+      (doseq [method [:put :patch]]
+
+        (fact "with an invalid JWToken"
+          (let [response (mock/api-request method (section-rep/url r/slug :update) {:body r/text-section-2
+                                                                                    :auth mock/jwtoken-bad})]
             (:status response) => 401
-            (:body response) => common/unauthorized))
-
-        (fact "with no company matching the company slug"
-          (let [response (mock/api-request :options (section-rep/url "foo" :update))]
-            (:status response) => 404
-            (:body response) => ""))
-
-        (fact "with no section matching the section name"
-          (let [response (mock/api-request :options (section-rep/url r/slug :diversity))]
-            (:status response) => 404
-            (:body response) => ""))
+            (:body response) => common/unauthorized)
+          ;; verify the initial section is unchanged
+          (s/get-section conn r/slug :update) => (contains r/text-section-1)
+          (count (s/get-revisions conn r/slug :update)) => 1)
 
         (fact "with no JWToken"
-          (let [response (mock/api-request :options (section-rep/url r/slug :update) {:skip-auth true})]
-            (:status response) => 204
-            (:body response) => ""
-            ((:headers response) "Allow") => limited-options))
+          (let [response (mock/api-request method (section-rep/url r/slug :update) {:body r/text-section-2
+                                                                                    :skip-auth true})]
+            (:status response) => 401
+            (:body response) => common/unauthorized)
+          ;; verify the initial section is unchanged
+          (s/get-section conn r/slug :update) => (contains r/text-section-1)
+          (count (s/get-revisions conn r/slug :update)) => 1)
 
         (fact "with an organization that doesn't match the company"
-          (let [response (mock/api-request :options (section-rep/url r/slug :update) {:auth mock/jwtoken-sartre})]
-            (:status response) => 204
-            (:body response) => ""
-            ((:headers response) "Allow") => limited-options))
+          (let [response (mock/api-request method (section-rep/url r/slug :update) {:body r/text-section-2
+                                                                                    :auth mock/jwtoken-sartre})]
+            (:status response) => 403
+            (:body response) => common/forbidden)
+          ;; verify the initial section is unchanged
+          (s/get-section conn r/slug :update) => (contains r/text-section-1)
+          (count (s/get-revisions conn r/slug :update)) => 1)
 
-        (fact "with an organization that matches the company"
-          (let [response (mock/api-request :options (section-rep/url r/slug :update))]
-            (:status response) => 204
-            (:body response) => ""
-            ((:headers response) "Allow") => full-options)))
+        (fact "with no company matching the company slug"
+          (let [response (mock/api-request method (section-rep/url "foo" :update) {:body r/text-section-2})]
+            (:status response) => 404
+            (:body response) => "")
+          ;; verify the initial section is unchanged
+          (s/get-section conn r/slug :update) => (contains r/text-section-1)
+          (count (s/get-revisions conn r/slug :update)) => 1)
 
-      (facts "about failing to update a section"
+        (fact "with no section matching the section name"
+          (let [response (mock/api-request method (section-rep/url r/slug :finances) {:body r/text-section-2})]
+            (:status response) => 404
+            (:body response) => "")
+          ;; verify the initial section is unchanged
+          (s/get-section conn r/slug :update) => (contains r/text-section-1)
+          (count (s/get-revisions conn r/slug :update)) => 1))))
 
-        (doseq [method [:put :patch]]
+  (facts "about updating an existing section revision"
 
-          (fact "with an invalid JWToken"
-            (let [response (mock/api-request method (section-rep/url r/slug :update) {:body r/text-section-2
-                                                                                      :auth mock/jwtoken-bad})]
-              (:status response) => 401
-              (:body response) => common/unauthorized)
-            ;; verify the initial section is unchanged
-            (s/get-section conn r/slug :update) => (contains r/text-section-1)
-            (count (s/get-revisions conn r/slug :update)) => 1)
+    (facts "with PUT"
 
-          (fact "with no JWToken"
-            (let [response (mock/api-request method (section-rep/url r/slug :update) {:body r/text-section-2
-                                                                                      :skip-auth true})]
-              (:status response) => 401
-              (:body response) => common/unauthorized)
-            ;; verify the initial section is unchanged
-            (s/get-section conn r/slug :update) => (contains r/text-section-1)
-            (count (s/get-revisions conn r/slug :update)) => 1)
+      (with-state-changes [(before :facts (s/put-section conn r/slug :update r/text-section-1 r/coyote))]
 
-          (fact "with an organization that doesn't match the company"
-            (let [response (mock/api-request method (section-rep/url r/slug :update) {:body r/text-section-2
-                                                                                      :auth mock/jwtoken-sartre})]
-              (:status response) => 403
-              (:body response) => common/forbidden)
-            ;; verify the initial section is unchanged
-            (s/get-section conn r/slug :update) => (contains r/text-section-1)
-            (count (s/get-revisions conn r/slug :update)) => 1)
+        (fact "update existing revision title"
+          (let [updated (assoc r/text-section-1 :title "New Title")
+                response (mock/api-request :put (section-rep/url r/slug :update) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)]
+            (:status response) => 200
+            body => (contains updated)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :update)]
+              updated-section => (contains updated)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :update)) => 1)) ; but there is still just 1 revision
 
-          (fact "with no company matching the company slug"
-            (let [response (mock/api-request method (section-rep/url "foo" :update) {:body r/text-section-2})]
-              (:status response) => 404
-              (:body response) => "")
-            ;; verify the initial section is unchanged
-            (s/get-section conn r/slug :update) => (contains r/text-section-1)
-            (count (s/get-revisions conn r/slug :update)) => 1)
+        (fact "update existing revision body"
+          (let [updated (assoc r/text-section-1 :body "New Body")
+                response (mock/api-request :put (section-rep/url r/slug :update) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)]
+            (:status response) => 200
+            body => (contains updated)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :update)]
+              updated-section => (contains updated)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :update)) => 1))) ; but there is still just 1 revision
 
-          (fact "with no section matching the section name"
-            (let [response (mock/api-request method (section-rep/url r/slug :finances) {:body r/text-section-2})]
-              (:status response) => 404
-              (:body response) => "")
-            ;; verify the initial section is unchanged
-            (s/get-section conn r/slug :update) => (contains r/text-section-1)
-            (count (s/get-revisions conn r/slug :update)) => 1))))
+      (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-section-1 r/coyote))]
 
-    (facts "about updating an existing section revision"
+        (fact "update existing revision note"
+          (let [updated (assoc r/text-section-1 :note "New Note")
+                response (mock/api-request :put (section-rep/url r/slug :finances) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)]
+            (:status response) => 200
+            body => (contains updated)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :finances)]
+              updated-section => (contains updated)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 1)) ; but there is still just 1 revision
 
-      (facts "with PUT"
+        (fact "update existing revision title, body and note"
+          (let [updated {:body "New Body" :title "New Title" :note "New Note"}
+                response (mock/api-request :put (section-rep/url r/slug :finances) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)]
+            (:status response) => 200
+            body => (contains updated)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :finances)]
+              updated-section => (contains updated)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 1)))) ; but there is still just 1 revision
 
-        (with-state-changes [(before :facts (s/put-section conn r/slug :update r/text-section-1 r/coyote))]
+    (facts "with PATCH"
 
-          (fact "update existing revision title"
-            (let [updated (assoc r/text-section-1 :title "New Title")
-                  response (mock/api-request :put (section-rep/url r/slug :update) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)]
-              (:status response) => 200
-              body => (contains updated)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :update)]
-                updated-section => (contains updated)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :update)) => 1)) ; but there is still just 1 revision
+      (with-state-changes [(before :facts (s/put-section conn r/slug :update r/text-section-1 r/coyote))]
 
-          (fact "update existing revision body"
-            (let [updated (assoc r/text-section-1 :body "New Body")
-                  response (mock/api-request :put (section-rep/url r/slug :update) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)]
-              (:status response) => 200
-              body => (contains updated)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :update)]
-                updated-section => (contains updated)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :update)) => 1))) ; but there is still just 1 revision
+        (fact "update existing revision title"
+          (let [updated {:title "New Title"}
+                response (mock/api-request :patch (section-rep/url r/slug :update) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)
+                updated-section (merge r/text-section-1 updated)]
+            (:status response) => 200
+            body => (contains updated-section)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :update)]
+              updated-section => (contains updated-section)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :update)) => 1)) ; but there is still just 1 revision
 
-        (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-section-1 r/coyote))]
+        (fact "update existing revision body"
+          (let [updated {:body "New Body"}
+                response (mock/api-request :patch (section-rep/url r/slug :update) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)
+                updated-section (merge r/text-section-1 updated)]
+            (:status response) => 200
+            body => (contains updated-section)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :update)]
+              updated-section => (contains updated-section)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :update)) => 1))) ; but there is still just 1 revision
 
-          (fact "update existing revision note"
-            (let [updated (assoc r/text-section-1 :note "New Note")
-                  response (mock/api-request :put (section-rep/url r/slug :finances) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)]
-              (:status response) => 200
-              body => (contains updated)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :finances)]
-                updated-section => (contains updated)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :finances)) => 1)) ; but there is still just 1 revision
+      (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-section-1 r/coyote))]
 
-          (fact "update existing revision title, body and note"
-            (let [updated {:body "New Body" :title "New Title" :note "New Note"}
-                  response (mock/api-request :put (section-rep/url r/slug :finances) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)]
-              (:status response) => 200
-              body => (contains updated)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :finances)]
-                updated-section => (contains updated)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :finances)) => 1)))) ; but there is still just 1 revision
+        (fact "update existing revision note"
+          (let [updated {:note "New Note"}
+                response (mock/api-request :patch (section-rep/url r/slug :finances) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)
+                updated-section (merge r/finances-section-1 updated)]
+            (:status response) => 200
+            body => (contains updated-section)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :finances)]
+              updated-section => (contains updated-section)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 1)) ; but there is still just 1 revision
 
-      (facts "with PATCH"
+        (fact "update existing revision title, body and note"
+          (let [updated {:body "New Body" :title "New Title" :note "New Note"}
+                response (mock/api-request :patch (section-rep/url r/slug :finances) {:body updated})
+                body (mock/body-from-response response)
+                updated-at (:updated-at body)]
+            (:status response) => 200
+            body => (contains updated)
+            ;; verify the initial revision is changed
+            (let [updated-section (s/get-section conn r/slug :finances)]
+              updated-section => (contains updated)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? (:created-at updated-section) updated-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 1))))) ; but there is still just 1 revision
 
-        (with-state-changes [(before :facts (s/put-section conn r/slug :update r/text-section-1 r/coyote))]
+  (facts "about updating a placeholder section"
 
-          (fact "update existing revision title"
-            (let [updated {:title "New Title"}
-                  response (mock/api-request :patch (section-rep/url r/slug :update) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)
-                  updated-section (merge r/text-section-1 updated)]
-              (:status response) => 200
-              body => (contains updated-section)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :update)]
-                updated-section => (contains updated-section)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :update)) => 1)) ; but there is still just 1 revision
+    (facts "with PUT"
+      (with-state-changes [(before :facts (c/create-company! conn (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
+                           (after :facts (c/delete-company conn (:slug r/buffer)))]
+        (fact "update existing revision title"
+          (let [updated  (assoc r/text-section-1 :title "New Title")
+                response (mock/api-request :put (section-rep/url (:slug r/buffer) :update) {:body updated})
+                body     (mock/body-from-response response)
+                company  (c/get-company conn (:slug r/buffer))]
+            (:status response) => 200
+            (-> company :update :placeholder) => falsey
+            body => (contains updated)
+            (:placeholder body) => falsey))))
 
-          (fact "update existing revision body"
-            (let [updated {:body "New Body"}
-                  response (mock/api-request :patch (section-rep/url r/slug :update) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)
-                  updated-section (merge r/text-section-1 updated)]
-              (:status response) => 200
-              body => (contains updated-section)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :update)]
-                updated-section => (contains updated-section)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :update)) => 1))) ; but there is still just 1 revision
+    (facts "with PATCH"
+      (with-state-changes [(before :facts (c/create-company! conn (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
+                           (after :facts (c/delete-company conn (:slug r/buffer)))]
+        (fact "update existing revision title"
+          (let [updated  {:title "New Title"}
+                response (mock/api-request :patch (section-rep/url (:slug r/buffer) :update) {:body updated})
+                body     (mock/body-from-response response)
+                company  (c/get-company conn (:slug r/buffer))]
+            (:status response) => 200
+            (-> company :update :placeholder) => falsey
+            (:title body) => (:title updated)
+            (:placeholder body) => falsey))))
 
-        (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-section-1 r/coyote))]
+    (future-facts "with DELETE"
+                  #_(with-state-changes [(before :facts (c/create-company! conn (c/->company r/buffer r/coyote)))
+                                         (after :facts (c/delete-company conn (:slug r/buffer)))]
+                      (fact "update existing revision title"
+                        (let [response (mock/api-request :delete (section-rep/url (:slug r/buffer) :update))
+                              body     (mock/body-from-response response)
+                              company  (c/get-company conn (:slug r/buffer))]
+                          (:status response) => 200
+                          (-> company :update) => nil)))))
 
-          (fact "update existing revision note"
-            (let [updated {:note "New Note"}
-                  response (mock/api-request :patch (section-rep/url r/slug :finances) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)
-                  updated-section (merge r/finances-section-1 updated)]
-              (:status response) => 200
-              body => (contains updated-section)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :finances)]
-                updated-section => (contains updated-section)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :finances)) => 1)) ; but there is still just 1 revision
-
-          (fact "update existing revision title, body and note"
-            (let [updated {:body "New Body" :title "New Title" :note "New Note"}
-                  response (mock/api-request :patch (section-rep/url r/slug :finances) {:body updated})
-                  body (mock/body-from-response response)
-                  updated-at (:updated-at body)]
-              (:status response) => 200
-              body => (contains updated)
-              ;; verify the initial revision is changed
-              (let [updated-section (s/get-section conn r/slug :finances)]
-                updated-section => (contains updated)
-                (check/timestamp? updated-at) => true
-                (check/about-now? updated-at) => true
-                (check/before? (:created-at updated-section) updated-at) => true)
-              (count (s/get-revisions conn r/slug :finances)) => 1))))) ; but there is still just 1 revision
-
-    (facts "about updating a placeholder section"
-
-      (facts "with PUT"
-        (with-state-changes [(before :facts (c/create-company! conn (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
-                             (after :facts (c/delete-company conn (:slug r/buffer)))]
-          (fact "update existing revision title"
-            (let [updated  (assoc r/text-section-1 :title "New Title")
-                  response (mock/api-request :put (section-rep/url (:slug r/buffer) :update) {:body updated})
-                  body     (mock/body-from-response response)
-                  company  (c/get-company conn (:slug r/buffer))]
-              (:status response) => 200
-              (-> company :update :placeholder) => falsey
-              body => (contains updated)
-              (:placeholder body) => falsey))))
-
-      (facts "with PATCH"
-        (with-state-changes [(before :facts (c/create-company! conn (c/add-core-placeholder-sections (c/->company r/buffer r/coyote))))
-                             (after :facts (c/delete-company conn (:slug r/buffer)))]
-          (fact "update existing revision title"
-            (let [updated  {:title "New Title"}
-                  response (mock/api-request :patch (section-rep/url (:slug r/buffer) :update) {:body updated})
-                  body     (mock/body-from-response response)
-                  company  (c/get-company conn (:slug r/buffer))]
-              (:status response) => 200
-              (-> company :update :placeholder) => falsey
-              (:title body) => (:title updated)
-              (:placeholder body) => falsey))))
-
-      (future-facts "with DELETE"
-                    #_(with-state-changes [(before :facts (c/create-company! conn (c/->company r/buffer r/coyote)))
-                                           (after :facts (c/delete-company conn (:slug r/buffer)))]
-                        (fact "update existing revision title"
-                          (let [response (mock/api-request :delete (section-rep/url (:slug r/buffer) :update))
-                                body     (mock/body-from-response response)
-                                company  (c/get-company conn (:slug r/buffer))]
-                            (:status response) => 200
-                            (-> company :update) => nil)))))
-
-    (future-facts "about creating a new section revision"
-                  (future-facts "with PUT")
-                  (future-facts "with PATCH"))))
+  (future-facts "about creating a new section revision"
+                (future-facts "with PUT")
+                (future-facts "with PATCH"))))

--- a/test/open_company/lib/db.clj
+++ b/test/open_company/lib/db.clj
@@ -6,18 +6,14 @@
             [open-company.resources.common :as common]
             [open-company.resources.section :as section]))
 
-(defn test-startup
-  "Start a minimal DB pool to support running sequential tests."
-  []
-  (pool/rebuild-pool! pool/rethinkdb-pool))
-
 (defn postdate
   "Push the timestamps of the specified section back to 1 second before the collapse-edit-time time limit."
-  [company-slug section-name]
-  (if-let [section (section/get-section company-slug section-name)]
+  [conn company-slug section-name]
+  (if-let [section (section/get-section conn company-slug section-name)]
     (let [original-at (f/parse (:updated-at section))
           new-at (t/minus original-at (t/seconds (inc (* 60 config/collapse-edit-time))))]
       (common/update-resource
+       conn
         section/table-name
         section/primary-key
         section

--- a/test/open_company/lib/rest_api_mock.clj
+++ b/test/open_company/lib/rest_api_mock.clj
@@ -5,6 +5,7 @@
             [ring.mock.request :refer (request body content-type header)]
             [cheshire.core :as json]
             [open-company.app :refer (app)]
+            [open-company.lib.test-setup :as ts]
             [open-company.representations.company :as company-rep]))
 
 ;; JWToken for use with QA profile - matches open-company.lib.resources/coyote
@@ -49,7 +50,7 @@
         headers-request (apply-headers initial-request headers-auth)
         body-value (:body options)
         body-request (if (:skip-body options) headers-request (body headers-request (json/generate-string body-value)))]
-    (app body-request))))
+    ((-> ts/test-system deref :handler :handler) body-request))))
 
 (defn body-from-response
   "Return just the parsed JSON body from an API REST response, or return the raw result

--- a/test/open_company/lib/test_setup.clj
+++ b/test/open_company/lib/test_setup.clj
@@ -1,0 +1,15 @@
+(ns open-company.lib.test-setup
+  (:require [com.stuartsierra.component :as component]
+            [open-company.components :as components]
+            [open-company.app :as app]))
+
+(def test-system (atom nil))
+
+(defn setup-system! []
+  (let [sys (components/oc-system {:handler-fn app/app :port 3000})]
+    ;; We don't need the server since we're mocking the requests
+    (reset! test-system (component/start (dissoc sys :server)))))
+
+(defn teardown-system! []
+  (component/stop @test-system)
+  (reset! test-system nil))

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -18,57 +18,57 @@
                                      (c/delete-all-companies! conn)))]
 
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
-    (facts "about company creation"
+  (facts "about company creation"
 
-      (fact "it fails to create a company if no org-id is provided"
-        (c/create-company! conn (c/->company r/open (dissoc r/coyote :org-id))) => (throws Exception))
+    (fact "it fails to create a company if no org-id is provided"
+      (c/create-company! conn (c/->company r/open (dissoc r/coyote :org-id))) => (throws Exception))
 
-      (facts "it returns the company after successful creation"
-        (c/create-company! conn (c/->company r/open r/coyote)) => (contains r/open)
-        (c/get-company conn r/slug) => (contains r/open))
+    (facts "it returns the company after successful creation"
+      (c/create-company! conn (c/->company r/open r/coyote)) => (contains r/open)
+      (c/get-company conn r/slug) => (contains r/open))
 
-      (facts "it accepts unicode company names"
-        (doseq [good-name r/names]
-          (let [new-oc (assoc r/open :name good-name)]
-            (c/create-company! conn (c/->company new-oc r/coyote)) => (contains new-oc)
-            (c/get-company conn r/slug) => (contains new-oc)
-            (c/delete-company conn r/slug))))
+    (facts "it accepts unicode company names"
+      (doseq [good-name r/names]
+        (let [new-oc (assoc r/open :name good-name)]
+          (c/create-company! conn (c/->company new-oc r/coyote)) => (contains new-oc)
+          (c/get-company conn r/slug) => (contains new-oc)
+          (c/delete-company conn r/slug))))
 
-      (facts "it creates timestamps"
-        (let [company (c/create-company! conn (c/->company r/open r/coyote))
-              created-at (:created-at company)
-              updated-at (:updated-at company)
-              retrieved-company (c/get-company conn r/slug)]
-          (check/timestamp? created-at) => true
-          (check/about-now? created-at) = true
-          (= created-at updated-at) => true
-          (= created-at (:created-at retrieved-company)) => true
-          (= updated-at (:updated-at retrieved-company)) => true))
+    (facts "it creates timestamps"
+      (let [company (c/create-company! conn (c/->company r/open r/coyote))
+            created-at (:created-at company)
+            updated-at (:updated-at company)
+            retrieved-company (c/get-company conn r/slug)]
+        (check/timestamp? created-at) => true
+        (check/about-now? created-at) = true
+        (= created-at updated-at) => true
+        (= created-at (:created-at retrieved-company)) => true
+        (= updated-at (:updated-at retrieved-company)) => true))
 
-      (facts "it adds timestamps to notes"
-        (let [co (c/->company (assoc r/open :finances r/finances-notes-section-1) r/coyote)
-              company (c/create-company! conn co)
-              from-db (c/get-company conn (:slug r/open))]
-          (get-in from-db [:updated-at]) => (:updated-at company)
-          (get-in from-db [:finances :notes :updated-at]) => (:updated-at company)))
+    (facts "it adds timestamps to notes"
+      (let [co (c/->company (assoc r/open :finances r/finances-notes-section-1) r/coyote)
+            company (c/create-company! conn co)
+            from-db (c/get-company conn (:slug r/open))]
+        (get-in from-db [:updated-at]) => (:updated-at company)
+        (get-in from-db [:finances :notes :updated-at]) => (:updated-at company)))
 
-      (fact "it returns the pre-defined categories"
-        (:categories (c/create-company! conn (c/->company r/open r/coyote))) => common/category-names)
+    (fact "it returns the pre-defined categories"
+      (:categories (c/create-company! conn (c/->company r/open r/coyote))) => common/category-names)
 
-      (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
-        (facts "it returns the sections in the company in the pre-defined order"
-          (:sections (c/create-company! conn (c/->company r/open r/coyote))) => {:progress [] :financial [] :company []}
-          (c/delete-company conn r/slug)
-          (:sections (c/create-company! conn (c/->company (add-section r/open :update) r/coyote))) =>
-          {:progress [:update] :financial [] :company []}
-          (c/delete-company conn r/slug)
-          (:sections (c/create-company! conn (c/->company (add-section r/open :values) r/coyote))) =>
-          {:progress [] :financial [] :company [:values]}
-          (c/delete-company conn r/slug)
-          (:sections (c/create-company!
-                      conn
-                      (c/->company (-> r/open
-                                       (add-section :mission) (add-section :press) (add-section :help)
-                                       (add-section :challenges) (add-section :diversity) (add-section :update))
-                                   r/coyote)))
-          => {:progress [:update :challenges :press] :financial [] :company [:mission :diversity :help]})))))
+    (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
+      (facts "it returns the sections in the company in the pre-defined order"
+        (:sections (c/create-company! conn (c/->company r/open r/coyote))) => {:progress [] :financial [] :company []}
+        (c/delete-company conn r/slug)
+        (:sections (c/create-company! conn (c/->company (add-section r/open :update) r/coyote))) =>
+        {:progress [:update] :financial [] :company []}
+        (c/delete-company conn r/slug)
+        (:sections (c/create-company! conn (c/->company (add-section r/open :values) r/coyote))) =>
+        {:progress [] :financial [] :company [:values]}
+        (c/delete-company conn r/slug)
+        (:sections (c/create-company!
+                    conn
+                    (c/->company (-> r/open
+                                     (add-section :mission) (add-section :press) (add-section :help)
+                                     (add-section :challenges) (add-section :diversity) (add-section :update))
+                                 r/coyote)))
+        => {:progress [:update :challenges :press] :financial [] :company [:mission :diversity :help]})))))

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -3,45 +3,49 @@
             [open-company.lib.check :as check]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
+            [open-company.lib.test-setup :as ts]
+            [open-company.db.pool :as pool]
             [open-company.resources.common :as common]
             [open-company.resources.company :as c]))
 
-;; ----- Startup -----
-
-(db/test-startup)
-
 ;; ----- Tests -----
 
-(with-state-changes [(before :facts (c/delete-all-companies!))
-                     (after :facts (c/delete-all-companies!))]
+(with-state-changes [(before :contents (ts/setup-system!))
+                     (after :contents (ts/teardown-system!))
+                     (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                      (c/delete-all-companies! conn)))
+                     (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                     (c/delete-all-companies! conn)))]
 
-  (facts "about company creation"
+  (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+    (facts "about company creation"
 
-    (fact "it fails to create a company if no org-id is provided"
-      (c/create-company! (c/->company r/open (dissoc r/coyote :org-id))) => (throws Exception))
+      (fact "it fails to create a company if no org-id is provided"
+        (c/create-company! conn (c/->company r/open (dissoc r/coyote :org-id))) => (throws Exception))
 
-    (facts "it returns the company after successful creation"
-      (c/create-company! (c/->company r/open r/coyote)) => (contains r/open)
-      (c/get-company r/slug) => (contains r/open))
+      (facts "it returns the company after successful creation"
+        (c/create-company! conn (c/->company r/open r/coyote)) => (contains r/open)
+        (c/get-company conn r/slug) => (contains r/open))
 
-    (facts "it accepts unicode company names"
-      (doseq [good-name r/names]
-        (let [new-oc (assoc r/open :name good-name)]
-          (c/create-company! (c/->company new-oc r/coyote)) => (contains new-oc)
-          (c/get-company r/slug) => (contains new-oc)
-          (c/delete-company r/slug))))
+      (facts "it accepts unicode company names"
+        (doseq [good-name r/names]
+          (let [new-oc (assoc r/open :name good-name)]
+            (c/create-company! conn (c/->company new-oc r/coyote)) => (contains new-oc)
+            (c/get-company conn r/slug) => (contains new-oc)
+            (c/delete-company conn r/slug))))
 
-    (facts "it creates timestamps"
-      (let [company (c/create-company! (c/->company r/open r/coyote))
-            created-at (:created-at company)
-            updated-at (:updated-at company)
-            retrieved-company (c/get-company r/slug)]
-        (check/timestamp? created-at) => true
-        (check/about-now? created-at) = true
-        (= created-at updated-at) => true
-        (= created-at (:created-at retrieved-company)) => true
-        (= updated-at (:updated-at retrieved-company)) => true))
+      (facts "it creates timestamps"
+        (let [company (c/create-company! conn (c/->company r/open r/coyote))
+              created-at (:created-at company)
+              updated-at (:updated-at company)
+              retrieved-company (c/get-company conn r/slug)]
+          (check/timestamp? created-at) => true
+          (check/about-now? created-at) = true
+          (= created-at updated-at) => true
+          (= created-at (:created-at retrieved-company)) => true
+          (= updated-at (:updated-at retrieved-company)) => true))
 
+<<<<<<< d3ab26991d01cd84e6a745774dcd70ad92009ff4
     (facts "it adds timestamps to notes"
       (let [co (c/->company (assoc r/open :finances r/finances-notes-section-1) r/coyote)
             company (c/create-company! co)
@@ -68,3 +72,33 @@
                                      (add-section :challenges) (add-section :diversity) (add-section :update))
                                  r/coyote)))
         => {:progress [:update :challenges :press] :financial [] :company [:mission :diversity :help]}))))
+=======
+      (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
+        (facts "it adds timestamps to notes"
+          (let [w-note  (-> r/open (add-section :growth) (assoc-in [:growth :notes :body] "A Note"))
+                co      (c/->company w-note r/coyote)
+                company (c/create-company! conn co)
+                from-db (c/get-company conn (:slug r/open))]
+            (get-in from-db [:updated-at]) => (:updated-at company)
+            (get-in from-db [:growth :notes :updated-at]) => (:updated-at company)))
+
+        (fact "it returns the pre-defined categories"
+          (:categories (c/create-company! conn (c/->company r/open r/coyote))) => (contains common/category-names))
+
+        (facts "it returns the sections in the company in the pre-defined order"
+          (:sections (c/create-company! conn (c/->company r/open r/coyote))) => {:progress [] :financial [] :company []}
+          (c/delete-company conn r/slug)
+          (:sections (c/create-company! conn (c/->company (add-section r/open :update) r/coyote))) =>
+          {:progress [:update] :financial [] :company []}
+          (c/delete-company conn r/slug)
+          (:sections (c/create-company! conn (c/->company (add-section r/open :values) r/coyote))) =>
+          {:progress [] :financial [] :company [:values]}
+          (c/delete-company conn r/slug)
+          (:sections (c/create-company!
+                      conn
+                      (c/->company (-> r/open
+                                       (add-section :mission) (add-section :press) (add-section :help)
+                                       (add-section :challenges) (add-section :diversity) (add-section :update))
+                                   r/coyote)))
+          => {:progress [:update :challenges :press :help] :financial [] :company [:diversity :mission]})))))
+>>>>>>> provide testing setup & fix all tests

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -3,8 +3,8 @@
             [open-company.lib.check :as check]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
-            [open-company.lib.test-setup :as ts]
             [open-company.db.pool :as pool]
+            [open-company.lib.test-setup :as ts]
             [open-company.resources.common :as common]
             [open-company.resources.company :as c]))
 
@@ -45,46 +45,17 @@
           (= created-at (:created-at retrieved-company)) => true
           (= updated-at (:updated-at retrieved-company)) => true))
 
-<<<<<<< d3ab26991d01cd84e6a745774dcd70ad92009ff4
-    (facts "it adds timestamps to notes"
-      (let [co (c/->company (assoc r/open :finances r/finances-notes-section-1) r/coyote)
-            company (c/create-company! co)
-            from-db (c/get-company (:slug r/open))]
-        (get-in from-db [:updated-at]) => (:updated-at company)
-        (get-in from-db [:finances :notes :updated-at]) => (:updated-at company)))
+      (facts "it adds timestamps to notes"
+        (let [co (c/->company (assoc r/open :finances r/finances-notes-section-1) r/coyote)
+              company (c/create-company! conn co)
+              from-db (c/get-company conn (:slug r/open))]
+          (get-in from-db [:updated-at]) => (:updated-at company)
+          (get-in from-db [:finances :notes :updated-at]) => (:updated-at company)))
 
-    (fact "it returns the pre-defined categories"
-      (:categories (c/create-company! (c/->company r/open r/coyote))) => common/category-names)
+      (fact "it returns the pre-defined categories"
+        (:categories (c/create-company! conn (c/->company r/open r/coyote))) => common/category-names)
 
-    (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
-      (facts "it returns the sections in the company in the pre-defined order"
-        (:sections (c/create-company! (c/->company r/open r/coyote))) => {:progress [] :financial [] :company []}
-        (c/delete-company r/slug)
-        (:sections (c/create-company! (c/->company (add-section r/open :update) r/coyote))) =>
-        {:progress [:update] :financial [] :company []}
-        (c/delete-company r/slug)
-        (:sections (c/create-company! (c/->company (add-section r/open :values) r/coyote))) =>
-        {:progress [] :financial [] :company [:values]}
-        (c/delete-company r/slug)
-        (:sections (c/create-company!
-                    (c/->company (-> r/open
-                                     (add-section :mission) (add-section :press) (add-section :help)
-                                     (add-section :challenges) (add-section :diversity) (add-section :update))
-                                 r/coyote)))
-        => {:progress [:update :challenges :press] :financial [] :company [:mission :diversity :help]}))))
-=======
       (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
-        (facts "it adds timestamps to notes"
-          (let [w-note  (-> r/open (add-section :growth) (assoc-in [:growth :notes :body] "A Note"))
-                co      (c/->company w-note r/coyote)
-                company (c/create-company! conn co)
-                from-db (c/get-company conn (:slug r/open))]
-            (get-in from-db [:updated-at]) => (:updated-at company)
-            (get-in from-db [:growth :notes :updated-at]) => (:updated-at company)))
-
-        (fact "it returns the pre-defined categories"
-          (:categories (c/create-company! conn (c/->company r/open r/coyote))) => (contains common/category-names))
-
         (facts "it returns the sections in the company in the pre-defined order"
           (:sections (c/create-company! conn (c/->company r/open r/coyote))) => {:progress [] :financial [] :company []}
           (c/delete-company conn r/slug)
@@ -100,5 +71,4 @@
                                        (add-section :mission) (add-section :press) (add-section :help)
                                        (add-section :challenges) (add-section :diversity) (add-section :update))
                                    r/coyote)))
-          => {:progress [:update :challenges :press :help] :financial [] :company [:diversity :mission]})))))
->>>>>>> provide testing setup & fix all tests
+          => {:progress [:update :challenges :press] :financial [] :company [:mission :diversity :help]})))))

--- a/test/open_company/unit/resources/company/company_list.clj
+++ b/test/open_company/unit/resources/company/company_list.clj
@@ -2,30 +2,32 @@
   (:require [midje.sweet :refer :all]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
+            [open-company.lib.test-setup :as ts]
+            [open-company.db.pool :as pool]
+            [open-company.lib.slugify :refer (slugify)]
             [open-company.resources.company :as c]))
-
-;; ----- Startup -----
-
-(db/test-startup)
 
 ;; ----- Tests -----
 
-(with-state-changes [(before :facts (do
-                                      (c/delete-all-companies!)
-                                      (c/create-company! (c/->company r/open r/coyote))
-                                      (c/create-company! (c/->company r/uni r/camus))
-                                      (c/create-company! (c/->company r/buffer r/sartre))))
-                     (after :facts (c/delete-all-companies!))]
+(with-state-changes [(before :contents (ts/setup-system!))
+                     (after :contents (ts/teardown-system!))
+                     (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                      (c/delete-all-companies! conn)
+                                      (c/create-company! conn (c/->company r/open r/coyote))
+                                      (c/create-company! conn (c/->company r/uni r/camus (slugify (:name r/uni))))
+                                      (c/create-company! conn (c/->company r/buffer r/sartre))))
+                     (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                     (c/delete-all-companies! conn)))]
 
-  (facts "about listing companies"
+  (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+    (facts "about listing companies"
+      (fact "all existing companies are listed"
+        (map :name (c/list-companies conn)) => (just (set (map :name [r/open r/uni r/buffer]))))
 
-    (fact "all existing companies are listed"
-      (map :name (c/list-companies)) => (just (set (map :name [r/open r/uni r/buffer]))))
+      (fact "removed companies are not listed"
+        (c/delete-company conn (:slug r/buffer))
+        (map :name (c/list-companies conn)) => (just (set (map :name [r/open r/uni]))))
 
-    (fact "removed companies are not listed"
-      (c/delete-company (:slug r/buffer))
-      (map :name (c/list-companies)) => (just (set (map :name [r/open r/uni]))))
-
-    (fact "companies can be queried via secondary indexes"
-      (count (c/get-companies-by-index "org-id" (:org-id r/sartre))) => 1
-      (:slug (first (c/get-companies-by-index "org-id" (:org-id r/sartre)))) => (:slug r/buffer))))
+      (fact "companies can be queried via secondary indexes"
+        (count (c/get-companies-by-index conn "org-id" (:org-id r/sartre))) => 1
+        (:slug (first (c/get-companies-by-index conn "org-id" (:org-id r/sartre)))) => (:slug r/buffer)))))

--- a/test/open_company/unit/resources/company/company_list.clj
+++ b/test/open_company/unit/resources/company/company_list.clj
@@ -20,14 +20,14 @@
                                      (c/delete-all-companies! conn)))]
 
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
-    (facts "about listing companies"
-      (fact "all existing companies are listed"
-        (map :name (c/list-companies conn)) => (just (set (map :name [r/open r/uni r/buffer]))))
+  (facts "about listing companies"
+    (fact "all existing companies are listed"
+      (map :name (c/list-companies conn)) => (just (set (map :name [r/open r/uni r/buffer]))))
 
-      (fact "removed companies are not listed"
-        (c/delete-company conn (:slug r/buffer))
-        (map :name (c/list-companies conn)) => (just (set (map :name [r/open r/uni]))))
+    (fact "removed companies are not listed"
+      (c/delete-company conn (:slug r/buffer))
+      (map :name (c/list-companies conn)) => (just (set (map :name [r/open r/uni]))))
 
-      (fact "companies can be queried via secondary indexes"
-        (count (c/get-companies-by-index conn "org-id" (:org-id r/sartre))) => 1
-        (:slug (first (c/get-companies-by-index conn "org-id" (:org-id r/sartre)))) => (:slug r/buffer)))))
+    (fact "companies can be queried via secondary indexes"
+      (count (c/get-companies-by-index conn "org-id" (:org-id r/sartre))) => 1
+      (:slug (first (c/get-companies-by-index conn "org-id" (:org-id r/sartre)))) => (:slug r/buffer)))))

--- a/test/open_company/unit/resources/company/company_manipulate.clj
+++ b/test/open_company/unit/resources/company/company_manipulate.clj
@@ -1,83 +1,85 @@
 (ns open-company.unit.resources.company.company-manipulate
   (:require [midje.sweet :refer :all]
+            [open-company.db.pool :as pool]
+            [open-company.lib.test-setup :as ts]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
             [open-company.resources.common :as common]
             [open-company.resources.company :as c]
             [open-company.resources.section :as s]))
 
-;; ----- Startup -----
-
-(db/test-startup)
-
 ;; ----- Tests -----
 
-(with-state-changes [(before :facts (do
-                                      (c/delete-all-companies!)
-                                      (c/create-company! (c/->company r/open r/coyote))))
-                     (after :facts (c/delete-all-companies!))]
+(with-state-changes [(before :contents (ts/setup-system!))
+                     (after :contents (ts/teardown-system!))
+                     (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                      (c/delete-all-companies! conn)
+                                      (c/create-company! conn (c/->company r/open r/coyote))))
+                     (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                     (c/delete-all-companies! conn)))]
 
-  (facts "about fixing up companies"
+  (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+    (facts "about fixing up companies"
 
-    (fact "with missing placeholder sections"
-      (let [company (c/get-company r/slug)
-            missing-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
-            fixed-company (c/add-placeholder-sections (merge company missing-sections))] ; this is what's tested
-        (:highlights fixed-company) => (-> (common/section-by-name "highlights")
-                                          (assoc :placeholder true)
-                                          (dissoc :core))
-        (:help fixed-company) => (-> (common/section-by-name "help")
-                                          (assoc :placeholder true)
-                                          (dissoc :core))
-        (:ownership fixed-company) => (-> (common/section-by-name "ownership")
-                                          (assoc :placeholder true)
-                                          (dissoc :core))))
+      (fact "with missing placeholder sections"
+        (let [company (c/get-company conn r/slug)
+              missing-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+              fixed-company (c/add-placeholder-sections (merge company missing-sections))] ; this is what's tested
+          (:highlights fixed-company) => (-> (common/section-by-name "highlights")
+                                             (assoc :placeholder true)
+                                             (dissoc :core))
+          (:help fixed-company) => (-> (common/section-by-name "help")
+                                       (assoc :placeholder true)
+                                       (dissoc :core))
+          (:ownership fixed-company) => (-> (common/section-by-name "ownership")
+                                            (assoc :placeholder true)
+                                            (dissoc :core))))
 
-    (future-fact "with partially specified placeholder sections"
-      (let [company (c/get-company r/slug)
-            updated-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
-            updated-content (-> updated-sections
-                              (assoc :highlights {:body "body a"})
-                              (assoc :help {:title "title b" :body "body b"})
-                              (assoc :ownership {:title "title c" :headline "headline c" :body "body c"}))
-            fixed-company (c/merge-company company updated-content)] ; this is what's tested
-        (:highlights fixed-company) => (-> (common/section-by-name "highlights")
-                                          (assoc :placeholder false)
-                                          (assoc :body "body a")
-                                          (dissoc :core))
-        (:help fixed-company) => (-> (common/section-by-name "help")
-                                          (assoc :placeholder false)
-                                          (assoc :title "title b")
-                                          (assoc :body "body b")
-                                          (dissoc :core))
-        (:ownership fixed-company) => (-> (common/section-by-name "ownership")
-                                          (assoc :placeholder false)
-                                          (assoc :title "title c")
-                                          (assoc :headline "headline c")
-                                          (assoc :body "body c")
-                                          (dissoc :core))))
+      (future-fact "with partially specified placeholder sections"
+                   (let [company (c/get-company conn r/slug)
+                         updated-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+                         updated-content (-> updated-sections
+                                             (assoc :highlights {:body "body a"})
+                                             (assoc :help {:title "title b" :body "body b"})
+                                             (assoc :ownership {:title "title c" :headline "headline c" :body "body c"}))
+                         fixed-company (c/merge-company company updated-content)] ; this is what's tested
+                     (:highlights fixed-company) => (-> (common/section-by-name "highlights")
+                                                        (assoc :placeholder false)
+                                                        (assoc :body "body a")
+                                                        (dissoc :core))
+                     (:help fixed-company) => (-> (common/section-by-name "help")
+                                                  (assoc :placeholder false)
+                                                  (assoc :title "title b")
+                                                  (assoc :body "body b")
+                                                  (dissoc :core))
+                     (:ownership fixed-company) => (-> (common/section-by-name "ownership")
+                                                       (assoc :placeholder false)
+                                                       (assoc :title "title c")
+                                                       (assoc :headline "headline c")
+                                                       (assoc :body "body c")
+                                                       (dissoc :core))))
 
-    (fact "with missing prior sections"
-      ; add the sections to be priors
-      (s/put-section r/slug :update r/text-section-1 r/coyote)
-      (s/put-section r/slug :values r/text-section-2 r/coyote)
-      (s/put-section r/slug :finances r/finances-section-1 r/coyote)
-      ; remove the sections
-      (let [company (c/get-company r/slug)
-            updated-company (-> company 
-                              (assoc :sections {:sections {:progress [] :company [] :financial []}})
-                              (dissoc :update))]
-        (c/update-company r/slug updated-company))
-      ; verify the sections are gone
-      (:update (c/get-company r/slug)) => nil
-      (:values (c/get-company r/slug)) => nil
-      (:finances (c/get-company r/slug)) => nil
-      ; velify missing prior sections comes back
-      (let [company (c/get-company r/slug)
-            missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
-            fixed-company (c/add-prior-sections (merge company missing-sections))] ; this is what's tested
-        (:update fixed-company) => (contains r/text-section-1)
-        (:values fixed-company) => (contains r/text-section-2)
-        (:finances fixed-company) => nil)) ; and that this one doesn't come back
+      (fact "with missing prior sections"
+                                        ; add the sections to be priors
+        (s/put-section conn r/slug :update r/text-section-1 r/coyote)
+        (s/put-section conn r/slug :values r/text-section-2 r/coyote)
+        (s/put-section conn r/slug :finances r/finances-section-1 r/coyote)
+                                        ; remove the sections
+        (let [company (c/get-company conn r/slug)
+              updated-company (-> company 
+                                  (assoc :sections {:sections {:progress [] :company [] :financial []}})
+                                  (dissoc :update))]
+          (c/update-company conn r/slug updated-company))
+                                        ; verify the sections are gone
+        (:update (c/get-company conn r/slug)) => nil
+        (:values (c/get-company conn r/slug)) => nil
+        (:finances (c/get-company conn r/slug)) => nil
+                                        ; velify missing prior sections comes back
+        (let [company (c/get-company conn r/slug)
+              missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
+              fixed-company (c/add-prior-sections conn (merge company missing-sections))] ; this is what's tested
+          (:update fixed-company) => (contains r/text-section-1)
+          (:values fixed-company) => (contains r/text-section-2)
+          (:finances fixed-company) => nil)) ; and that this one doesn't come back
 
-    (future-fact "with partially specified prior sections")))
+      (future-fact "with partially specified prior sections"))))

--- a/test/open_company/unit/resources/company/company_manipulate.clj
+++ b/test/open_company/unit/resources/company/company_manipulate.clj
@@ -60,21 +60,21 @@
                                           (dissoc :core))))
 
     (fact "with missing prior sections"
-                                      ; add the sections to be priors
+      ;; add the sections to be priors
       (s/put-section conn r/slug :update r/text-section-1 r/coyote)
       (s/put-section conn r/slug :values r/text-section-2 r/coyote)
       (s/put-section conn r/slug :finances r/finances-section-1 r/coyote)
-                                      ; remove the sections
+      ;; remove the sections
       (let [company (c/get-company conn r/slug)
             updated-company (-> company 
                                 (assoc :sections {:sections {:progress [] :company [] :financial []}})
                                 (dissoc :update))]
         (c/update-company conn r/slug updated-company))
-                                      ; verify the sections are gone
+      ;; verify the sections are gone
       (:update (c/get-company conn r/slug)) => nil
       (:values (c/get-company conn r/slug)) => nil
       (:finances (c/get-company conn r/slug)) => nil
-                                      ; velify missing prior sections comes back
+      ;; velify missing prior sections comes back
       (let [company (c/get-company conn r/slug)
             missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
             fixed-company (c/add-prior-sections conn (merge company missing-sections))] ; this is what's tested

--- a/test/open_company/unit/resources/company/company_manipulate.clj
+++ b/test/open_company/unit/resources/company/company_manipulate.clj
@@ -19,67 +19,67 @@
                                      (c/delete-all-companies! conn)))]
 
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
-    (facts "about fixing up companies"
+  (facts "about fixing up companies"
 
-      (fact "with missing placeholder sections"
-        (let [company (c/get-company conn r/slug)
-              missing-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
-              fixed-company (c/add-placeholder-sections (merge company missing-sections))] ; this is what's tested
-          (:highlights fixed-company) => (-> (common/section-by-name "highlights")
-                                             (assoc :placeholder true)
-                                             (dissoc :core))
-          (:help fixed-company) => (-> (common/section-by-name "help")
-                                       (assoc :placeholder true)
-                                       (dissoc :core))
-          (:ownership fixed-company) => (-> (common/section-by-name "ownership")
-                                            (assoc :placeholder true)
-                                            (dissoc :core))))
+    (fact "with missing placeholder sections"
+      (let [company (c/get-company conn r/slug)
+            missing-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+            fixed-company (c/add-placeholder-sections (merge company missing-sections))] ; this is what's tested
+        (:highlights fixed-company) => (-> (common/section-by-name "highlights")
+                                           (assoc :placeholder true)
+                                           (dissoc :core))
+        (:help fixed-company) => (-> (common/section-by-name "help")
+                                     (assoc :placeholder true)
+                                     (dissoc :core))
+        (:ownership fixed-company) => (-> (common/section-by-name "ownership")
+                                          (assoc :placeholder true)
+                                          (dissoc :core))))
 
-      (future-fact "with partially specified placeholder sections"
-                   (let [company (c/get-company conn r/slug)
-                         updated-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
-                         updated-content (-> updated-sections
-                                             (assoc :highlights {:body "body a"})
-                                             (assoc :help {:title "title b" :body "body b"})
-                                             (assoc :ownership {:title "title c" :headline "headline c" :body "body c"}))
-                         fixed-company (c/merge-company company updated-content)] ; this is what's tested
-                     (:highlights fixed-company) => (-> (common/section-by-name "highlights")
-                                                        (assoc :placeholder false)
-                                                        (assoc :body "body a")
-                                                        (dissoc :core))
-                     (:help fixed-company) => (-> (common/section-by-name "help")
-                                                  (assoc :placeholder false)
-                                                  (assoc :title "title b")
-                                                  (assoc :body "body b")
-                                                  (dissoc :core))
-                     (:ownership fixed-company) => (-> (common/section-by-name "ownership")
-                                                       (assoc :placeholder false)
-                                                       (assoc :title "title c")
-                                                       (assoc :headline "headline c")
-                                                       (assoc :body "body c")
-                                                       (dissoc :core))))
+    (future-fact "with partially specified placeholder sections"
+      (let [company (c/get-company conn r/slug)
+            updated-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+            updated-content (-> updated-sections
+                                (assoc :highlights {:body "body a"})
+                                (assoc :help {:title "title b" :body "body b"})
+                                (assoc :ownership {:title "title c" :headline "headline c" :body "body c"}))
+            fixed-company (c/merge-company company updated-content)] ; this is what's tested
+        (:highlights fixed-company) => (-> (common/section-by-name "highlights")
+                                           (assoc :placeholder false)
+                                           (assoc :body "body a")
+                                           (dissoc :core))
+        (:help fixed-company) => (-> (common/section-by-name "help")
+                                     (assoc :placeholder false)
+                                     (assoc :title "title b")
+                                     (assoc :body "body b")
+                                     (dissoc :core))
+        (:ownership fixed-company) => (-> (common/section-by-name "ownership")
+                                          (assoc :placeholder false)
+                                          (assoc :title "title c")
+                                          (assoc :headline "headline c")
+                                          (assoc :body "body c")
+                                          (dissoc :core))))
 
-      (fact "with missing prior sections"
-                                        ; add the sections to be priors
-        (s/put-section conn r/slug :update r/text-section-1 r/coyote)
-        (s/put-section conn r/slug :values r/text-section-2 r/coyote)
-        (s/put-section conn r/slug :finances r/finances-section-1 r/coyote)
-                                        ; remove the sections
-        (let [company (c/get-company conn r/slug)
-              updated-company (-> company 
-                                  (assoc :sections {:sections {:progress [] :company [] :financial []}})
-                                  (dissoc :update))]
-          (c/update-company conn r/slug updated-company))
-                                        ; verify the sections are gone
-        (:update (c/get-company conn r/slug)) => nil
-        (:values (c/get-company conn r/slug)) => nil
-        (:finances (c/get-company conn r/slug)) => nil
-                                        ; velify missing prior sections comes back
-        (let [company (c/get-company conn r/slug)
-              missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
-              fixed-company (c/add-prior-sections conn (merge company missing-sections))] ; this is what's tested
-          (:update fixed-company) => (contains r/text-section-1)
-          (:values fixed-company) => (contains r/text-section-2)
-          (:finances fixed-company) => nil)) ; and that this one doesn't come back
+    (fact "with missing prior sections"
+                                      ; add the sections to be priors
+      (s/put-section conn r/slug :update r/text-section-1 r/coyote)
+      (s/put-section conn r/slug :values r/text-section-2 r/coyote)
+      (s/put-section conn r/slug :finances r/finances-section-1 r/coyote)
+                                      ; remove the sections
+      (let [company (c/get-company conn r/slug)
+            updated-company (-> company 
+                                (assoc :sections {:sections {:progress [] :company [] :financial []}})
+                                (dissoc :update))]
+        (c/update-company conn r/slug updated-company))
+                                      ; verify the sections are gone
+      (:update (c/get-company conn r/slug)) => nil
+      (:values (c/get-company conn r/slug)) => nil
+      (:finances (c/get-company conn r/slug)) => nil
+                                      ; velify missing prior sections comes back
+      (let [company (c/get-company conn r/slug)
+            missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
+            fixed-company (c/add-prior-sections conn (merge company missing-sections))] ; this is what's tested
+        (:update fixed-company) => (contains r/text-section-1)
+        (:values fixed-company) => (contains r/text-section-2)
+        (:finances fixed-company) => nil)) ; and that this one doesn't come back
 
-      (future-fact "with partially specified prior sections"))))
+    (future-fact "with partially specified prior sections"))))

--- a/test/open_company/unit/resources/section/section_revision.clj
+++ b/test/open_company/unit/resources/section/section_revision.clj
@@ -52,163 +52,163 @@
                                      (c/delete-company conn r/slug)))]
 
   (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
-    (facts "about revising sections"
+  (facts "about revising sections"
 
-      (facts "when a sections is new"
+    (facts "when a sections is new"
 
-        (fact "creates a new section when the author is a member of the company org"
-          (s/put-section conn r/slug :update r/text-section-1 r/coyote)
-          (let [section (s/get-section conn r/slug :update)
-                updated-at (:updated-at section)]
+      (fact "creates a new section when the author is a member of the company org"
+        (s/put-section conn r/slug :update r/text-section-1 r/coyote)
+        (let [section (s/get-section conn r/slug :update)
+              updated-at (:updated-at section)]
+          (:author section) => (contains (common/author-for-user r/coyote))
+          (:body section) => (:body r/text-section-1)
+          (:title section) => (:title r/text-section-1)
+          (check/timestamp? updated-at) => true
+          (check/about-now? updated-at) => true
+          updated-at => (:created-at section))
+        (count (s/get-revisions conn r/slug :update)) => 1)
+
+      (fact "fails to create a new section when the author is NOT a member of the company org"
+        (s/put-section conn r/slug :update r/text-section-1 r/sartre) => false
+        (s/get-section conn r/slug :update) => nil
+        (count (s/get-revisions conn r/slug :update)) => 0))
+
+    (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-section-1 r/coyote))]
+
+      (fact "fails to update a section when the author is NOT a member of the company org"
+        (let [original-section (s/get-section conn r/slug :finances)]
+          (s/put-section conn r/slug :finances r/finances-notes-section-2 r/sartre) => false
+          (s/get-section conn r/slug :finances) => original-section
+          (count (s/get-revisions conn r/slug :finances)) => 1))
+
+      (facts "when the prior revision of the section DOESN'T have notes"
+
+        (fact "creates a new revision when the update of the section DOES have a note"
+          (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)
+                notes (:notes section)]
             (:author section) => (contains (common/author-for-user r/coyote))
-            (:body section) => (:body r/text-section-1)
-            (:title section) => (:title r/text-section-1)
+            (:data section) => (:data r/finances-notes-section-2)
+            (:title section) => (:title r/finances-notes-section-2)
             (check/timestamp? updated-at) => true
             (check/about-now? updated-at) => true
-            updated-at => (:created-at section))
-          (count (s/get-revisions conn r/slug :update)) => 1)
+            (= updated-at created-at) => true
+            (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
+            (:author notes) => (contains (common/author-for-user r/coyote))
+            (:updated-at notes) => updated-at)
+          (count (s/get-revisions conn r/slug :finances)) => 2)
 
-        (fact "fails to create a new section when the author is NOT a member of the company org"
-          (s/put-section conn r/slug :update r/text-section-1 r/sartre) => false
-          (s/get-section conn r/slug :update) => nil
-          (count (s/get-revisions conn r/slug :update)) => 0))
+        (fact "creates a new revision when the update of the section is by a different author"
+          (s/put-section conn r/slug :finances r/finances-section-2 r/camus)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)]
+            (:author section) => (contains (common/author-for-user r/camus))
+            (:data section) => (:data r/finances-section-2)
+            (:title section) => (:title r/finances-section-2)
+            (check/timestamp? updated-at) => true
+            (check/about-now? updated-at) => true
+            (= updated-at created-at) => true)
+          (count (s/get-revisions conn r/slug :finances)) => 2)
 
-      (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-section-1 r/coyote))]
+        (fact "creates a new revision when the update of the section is over the time limit"
+          (db/postdate conn r/slug :finances) ; long enough ago to trigger a new revision
+          (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)]
+            (:author section) => (contains (common/author-for-user r/coyote))
+            (:data section) => (:data r/finances-section-2)
+            (:title section) => (:title r/finances-section-2)
+            (check/timestamp? updated-at) => true
+            (check/about-now? updated-at) => true
+            (= updated-at created-at) => true)
+          (count (s/get-revisions conn r/slug :finances)) => 2)
 
-        (fact "fails to update a section when the author is NOT a member of the company org"
-          (let [original-section (s/get-section conn r/slug :finances)]
-            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/sartre) => false
-            (s/get-section conn r/slug :finances) => original-section
-            (count (s/get-revisions conn r/slug :finances)) => 1))
+        (fact "updates existing revision when the update of the section is by the same author & is under the time limit"
+          (check/delay-secs 1) ; not long enough to trigger a new revision
+          (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)]
+            (:author section) => (contains (common/author-for-user r/coyote))
+            (:data section) => (:data r/finances-section-2)
+            (:title section) => (:title r/finances-section-2)
+            (check/timestamp? updated-at) => true
+            (check/about-now? updated-at) => true
+            (check/before? created-at updated-at) => true)
+          (count (s/get-revisions conn r/slug :finances)) => 1)))
 
-        (facts "when the prior revision of the section DOESN'T have notes"
+    (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-notes-section-1 r/coyote))]
 
-          (fact "creates a new revision when the update of the section DOES have a note"
-            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)
-                  notes (:notes section)]
-              (:author section) => (contains (common/author-for-user r/coyote))
-              (:data section) => (:data r/finances-notes-section-2)
-              (:title section) => (:title r/finances-notes-section-2)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (= updated-at created-at) => true
-              (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
-              (:author notes) => (contains (common/author-for-user r/coyote))
-              (:updated-at notes) => updated-at)
-            (count (s/get-revisions conn r/slug :finances)) => 2)
+      (facts "when the prior revision of the section DOES have notes"
 
-          (fact "creates a new revision when the update of the section is by a different author"
-            (s/put-section conn r/slug :finances r/finances-section-2 r/camus)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)]
-              (:author section) => (contains (common/author-for-user r/camus))
-              (:data section) => (:data r/finances-section-2)
-              (:title section) => (:title r/finances-section-2)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (= updated-at created-at) => true)
-            (count (s/get-revisions conn r/slug :finances)) => 2)
+        (fact "creates a new revision when the update of the section DOESN'T have a note"
+          (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)]
+            (:author section) => (contains (common/author-for-user r/coyote))
+            (:data section) => (:data r/finances-section-2)
+            (:title section) => (:title r/finances-section-2)
+            (:notes section) => nil
+            (check/timestamp? updated-at) => true
+            (check/about-now? updated-at) => true
+            (= updated-at created-at) => true)
+          (count (s/get-revisions conn r/slug :finances)) => 2)
 
-          (fact "creates a new revision when the update of the section is over the time limit"
-            (db/postdate conn r/slug :finances) ; long enough ago to trigger a new revision
-            (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)]
-              (:author section) => (contains (common/author-for-user r/coyote))
-              (:data section) => (:data r/finances-section-2)
-              (:title section) => (:title r/finances-section-2)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (= updated-at created-at) => true)
-            (count (s/get-revisions conn r/slug :finances)) => 2)
+        (fact "creates a new revision when the update of the section is by a different author"
+          (s/put-section conn r/slug :finances r/finances-notes-section-2 r/camus)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)
+                notes (:notes section)]
+            (:author section) => (contains (common/author-for-user r/camus))
+            (:data section) => (:data r/finances-notes-section-2)
+            (:title section) => (:title r/finances-notes-section-2)
+            (check/timestamp? updated-at) => true
+            (check/about-now? updated-at) => true
+            (= updated-at created-at) => true
+            (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
+            (:author notes) => (contains (common/author-for-user r/camus))
+            (:updated-at notes) => updated-at)
+          (count (s/get-revisions conn r/slug :finances)) => 2)
 
-          (fact "updates existing revision when the update of the section is by the same author & is under the time limit"
-            (check/delay-secs 1) ; not long enough to trigger a new revision
-            (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)]
-              (:author section) => (contains (common/author-for-user r/coyote))
-              (:data section) => (:data r/finances-section-2)
-              (:title section) => (:title r/finances-section-2)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? created-at updated-at) => true)
-            (count (s/get-revisions conn r/slug :finances)) => 1)))
+        (fact "creates a new revision when the update of the section is over the time limit"
+          (db/postdate conn r/slug :finances) ; long enough ago to trigger a new revision
+          (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)
+                notes (:notes section)]
+            (:author section) => (contains (common/author-for-user r/coyote))
+            (:data section) => (:data r/finances-notes-section-2)
+            (:title section) => (:title r/finances-notes-section-2)
+            (check/timestamp? updated-at) => true
+            (check/about-now? updated-at) => true
+            (= created-at updated-at) => true
+            (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
+            (:author notes) => (contains (common/author-for-user r/coyote))
+            (:updated-at notes) => updated-at)
+          (count (s/get-revisions conn r/slug :finances)) => 2)
 
-      (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-notes-section-1 r/coyote))]
+        (future-fact "creates a new revision when the update of the section's note is by a different author")
 
-        (facts "when the prior revision of the section DOES have notes"
+        (future-fact "creates a new revision when the update of the section's note is over the time limit")
 
-          (fact "creates a new revision when the update of the section DOESN'T have a note"
-            (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)]
-              (:author section) => (contains (common/author-for-user r/coyote))
-              (:data section) => (:data r/finances-section-2)
-              (:title section) => (:title r/finances-section-2)
-              (:notes section) => nil
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (= updated-at created-at) => true)
-            (count (s/get-revisions conn r/slug :finances)) => 2)
-
-          (fact "creates a new revision when the update of the section is by a different author"
-            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/camus)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)
-                  notes (:notes section)]
-              (:author section) => (contains (common/author-for-user r/camus))
-              (:data section) => (:data r/finances-notes-section-2)
-              (:title section) => (:title r/finances-notes-section-2)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (= updated-at created-at) => true
-              (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
-              (:author notes) => (contains (common/author-for-user r/camus))
-              (:updated-at notes) => updated-at)
-            (count (s/get-revisions conn r/slug :finances)) => 2)
-
-          (fact "creates a new revision when the update of the section is over the time limit"
-            (db/postdate conn r/slug :finances) ; long enough ago to trigger a new revision
-            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)
-                  notes (:notes section)]
-              (:author section) => (contains (common/author-for-user r/coyote))
-              (:data section) => (:data r/finances-notes-section-2)
-              (:title section) => (:title r/finances-notes-section-2)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (= created-at updated-at) => true
-              (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
-              (:author notes) => (contains (common/author-for-user r/coyote))
-              (:updated-at notes) => updated-at)
-            (count (s/get-revisions conn r/slug :finances)) => 2)
-
-          (future-fact "creates a new revision when the update of the section's note is by a different author")
-
-          (future-fact "creates a new revision when the update of the section's note is over the time limit")
-
-          (fact "updates the existing revision when the update of the section & its note were by the same author &
-          are under the time limit"
-            (check/delay-secs 1) ; not long enough to trigger a new revision
-            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
-            (let [section (s/get-section conn r/slug :finances)
-                  updated-at (:updated-at section)
-                  created-at (:created-at section)]
-              (:author section) => (contains (common/author-for-user r/coyote))
-              (:data section) => (:data r/finances-notes-section-2)
-              (:title section) => (:title r/finances-notes-section-2)
-              (check/timestamp? updated-at) => true
-              (check/about-now? updated-at) => true
-              (check/before? created-at updated-at) => true)
-            (count (s/get-revisions conn r/slug :finances)) => 1))))))
+        (fact "updates the existing revision when the update of the section & its note were by the same author &
+        are under the time limit"
+          (check/delay-secs 1) ; not long enough to trigger a new revision
+          (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
+          (let [section (s/get-section conn r/slug :finances)
+                updated-at (:updated-at section)
+                created-at (:created-at section)]
+            (:author section) => (contains (common/author-for-user r/coyote))
+            (:data section) => (:data r/finances-notes-section-2)
+            (:title section) => (:title r/finances-notes-section-2)
+            (check/timestamp? updated-at) => true
+            (check/about-now? updated-at) => true
+            (check/before? created-at updated-at) => true)
+          (count (s/get-revisions conn r/slug :finances)) => 1))))))

--- a/test/open_company/unit/resources/section/section_revision.clj
+++ b/test/open_company/unit/resources/section/section_revision.clj
@@ -3,14 +3,12 @@
             [open-company.lib.check :as check]
             [open-company.lib.resources :as r]
             [open-company.lib.db :as db]
+            [open-company.lib.test-setup :as ts]
+            [open-company.db.pool :as pool]
             [open-company.config :as config]
             [open-company.resources.common :as common]
             [open-company.resources.company :as c]
             [open-company.resources.section :as s]))
-
-;; ----- Startup -----
-
-(db/test-startup)
 
 ;; ----- Test Cases -----
 
@@ -45,167 +43,172 @@
 
 ;; ----- Tests -----
 
-(with-state-changes [(before :facts (do (c/delete-company r/slug)
-                                        (c/create-company! (c/->company r/open r/coyote))))
-                     (after :facts (c/delete-company r/slug))]
+(with-state-changes [(before :contents (ts/setup-system!))
+                     (after :contents (ts/teardown-system!))
+                     (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                      (c/delete-company conn r/slug)
+                                      (c/create-company! conn (c/->company r/open r/coyote))))
+                     (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                     (c/delete-company conn r/slug)))]
 
-  (facts "about revising sections"
+  (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+    (facts "about revising sections"
 
-    (facts "when a sections is new"
+      (facts "when a sections is new"
 
-      (fact "creates a new section when the author is a member of the company org"
-        (s/put-section r/slug :update r/text-section-1 r/coyote)
-        (let [section (s/get-section r/slug :update)
-              updated-at (:updated-at section)]
-          (:author section) => (contains (common/author-for-user r/coyote))
-          (:body section) => (:body r/text-section-1)
-          (:title section) => (:title r/text-section-1)
-          (check/timestamp? updated-at) => true
-          (check/about-now? updated-at) => true
-          updated-at => (:created-at section))
-        (count (s/get-revisions r/slug :update)) => 1)
-
-      (fact "fails to create a new section when the author is NOT a member of the company org"
-        (s/put-section r/slug :update r/text-section-1 r/sartre) => false
-        (s/get-section r/slug :update) => nil
-        (count (s/get-revisions r/slug :update)) => 0))
-
-    (with-state-changes [(before :facts (s/put-section r/slug :finances r/finances-section-1 r/coyote))]
-
-      (fact "fails to update a section when the author is NOT a member of the company org"
-        (let [original-section (s/get-section r/slug :finances)]
-          (s/put-section r/slug :finances r/finances-notes-section-2 r/sartre) => false
-          (s/get-section r/slug :finances) => original-section
-          (count (s/get-revisions r/slug :finances)) => 1))
-
-      (facts "when the prior revision of the section DOESN'T have notes"
-
-        (fact "creates a new revision when the update of the section DOES have a note"
-          (s/put-section r/slug :finances r/finances-notes-section-2 r/coyote)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)
-                notes (:notes section)]
+        (fact "creates a new section when the author is a member of the company org"
+          (s/put-section conn r/slug :update r/text-section-1 r/coyote)
+          (let [section (s/get-section conn r/slug :update)
+                updated-at (:updated-at section)]
             (:author section) => (contains (common/author-for-user r/coyote))
-            (:data section) => (:data r/finances-notes-section-2)
-            (:title section) => (:title r/finances-notes-section-2)
+            (:body section) => (:body r/text-section-1)
+            (:title section) => (:title r/text-section-1)
             (check/timestamp? updated-at) => true
             (check/about-now? updated-at) => true
-            (= updated-at created-at) => true
-            (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
-            (:author notes) => (contains (common/author-for-user r/coyote))
-            (:updated-at notes) => updated-at)
-          (count (s/get-revisions r/slug :finances)) => 2)
+            updated-at => (:created-at section))
+          (count (s/get-revisions conn r/slug :update)) => 1)
 
-        (fact "creates a new revision when the update of the section is by a different author"
-          (s/put-section r/slug :finances r/finances-section-2 r/camus)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)]
-            (:author section) => (contains (common/author-for-user r/camus))
-            (:data section) => (:data r/finances-section-2)
-            (:title section) => (:title r/finances-section-2)
-            (check/timestamp? updated-at) => true
-            (check/about-now? updated-at) => true
-            (= updated-at created-at) => true)
-          (count (s/get-revisions r/slug :finances)) => 2)
+        (fact "fails to create a new section when the author is NOT a member of the company org"
+          (s/put-section conn r/slug :update r/text-section-1 r/sartre) => false
+          (s/get-section conn r/slug :update) => nil
+          (count (s/get-revisions conn r/slug :update)) => 0))
 
-        (fact "creates a new revision when the update of the section is over the time limit"
-          (db/postdate r/slug :finances) ; long enough ago to trigger a new revision
-          (s/put-section r/slug :finances r/finances-section-2 r/coyote)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)]
-            (:author section) => (contains (common/author-for-user r/coyote))
-            (:data section) => (:data r/finances-section-2)
-            (:title section) => (:title r/finances-section-2)
-            (check/timestamp? updated-at) => true
-            (check/about-now? updated-at) => true
-            (= updated-at created-at) => true)
-          (count (s/get-revisions r/slug :finances)) => 2)
+      (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-section-1 r/coyote))]
 
-        (fact "updates existing revision when the update of the section is by the same author & is under the time limit"
-          (check/delay-secs 1) ; not long enough to trigger a new revision
-          (s/put-section r/slug :finances r/finances-section-2 r/coyote)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)]
-            (:author section) => (contains (common/author-for-user r/coyote))
-            (:data section) => (:data r/finances-section-2)
-            (:title section) => (:title r/finances-section-2)
-            (check/timestamp? updated-at) => true
-            (check/about-now? updated-at) => true
-            (check/before? created-at updated-at) => true)
-          (count (s/get-revisions r/slug :finances)) => 1)))
+        (fact "fails to update a section when the author is NOT a member of the company org"
+          (let [original-section (s/get-section conn r/slug :finances)]
+            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/sartre) => false
+            (s/get-section conn r/slug :finances) => original-section
+            (count (s/get-revisions conn r/slug :finances)) => 1))
 
-    (with-state-changes [(before :facts (s/put-section r/slug :finances r/finances-notes-section-1 r/coyote))]
+        (facts "when the prior revision of the section DOESN'T have notes"
 
-      (facts "when the prior revision of the section DOES have notes"
+          (fact "creates a new revision when the update of the section DOES have a note"
+            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)
+                  notes (:notes section)]
+              (:author section) => (contains (common/author-for-user r/coyote))
+              (:data section) => (:data r/finances-notes-section-2)
+              (:title section) => (:title r/finances-notes-section-2)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (= updated-at created-at) => true
+              (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
+              (:author notes) => (contains (common/author-for-user r/coyote))
+              (:updated-at notes) => updated-at)
+            (count (s/get-revisions conn r/slug :finances)) => 2)
 
-        (fact "creates a new revision when the update of the section DOESN'T have a note"
-          (s/put-section r/slug :finances r/finances-section-2 r/coyote)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)]
-            (:author section) => (contains (common/author-for-user r/coyote))
-            (:data section) => (:data r/finances-section-2)
-            (:title section) => (:title r/finances-section-2)
-            (:notes section) => nil
-            (check/timestamp? updated-at) => true
-            (check/about-now? updated-at) => true
-            (= updated-at created-at) => true)
-          (count (s/get-revisions r/slug :finances)) => 2)
+          (fact "creates a new revision when the update of the section is by a different author"
+            (s/put-section conn r/slug :finances r/finances-section-2 r/camus)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)]
+              (:author section) => (contains (common/author-for-user r/camus))
+              (:data section) => (:data r/finances-section-2)
+              (:title section) => (:title r/finances-section-2)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (= updated-at created-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 2)
 
-        (fact "creates a new revision when the update of the section is by a different author"
-          (s/put-section r/slug :finances r/finances-notes-section-2 r/camus)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)
-                notes (:notes section)]
-            (:author section) => (contains (common/author-for-user r/camus))
-            (:data section) => (:data r/finances-notes-section-2)
-            (:title section) => (:title r/finances-notes-section-2)
-            (check/timestamp? updated-at) => true
-            (check/about-now? updated-at) => true
-            (= updated-at created-at) => true
-            (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
-            (:author notes) => (contains (common/author-for-user r/camus))
-            (:updated-at notes) => updated-at)
-          (count (s/get-revisions r/slug :finances)) => 2)
+          (fact "creates a new revision when the update of the section is over the time limit"
+            (db/postdate conn r/slug :finances) ; long enough ago to trigger a new revision
+            (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)]
+              (:author section) => (contains (common/author-for-user r/coyote))
+              (:data section) => (:data r/finances-section-2)
+              (:title section) => (:title r/finances-section-2)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (= updated-at created-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 2)
 
-        (fact "creates a new revision when the update of the section is over the time limit"
-          (db/postdate r/slug :finances) ; long enough ago to trigger a new revision
-          (s/put-section r/slug :finances r/finances-notes-section-2 r/coyote)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)
-                notes (:notes section)]
-            (:author section) => (contains (common/author-for-user r/coyote))
-            (:data section) => (:data r/finances-notes-section-2)
-            (:title section) => (:title r/finances-notes-section-2)
-            (check/timestamp? updated-at) => true
-            (check/about-now? updated-at) => true
-            (= created-at updated-at) => true
-            (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
-            (:author notes) => (contains (common/author-for-user r/coyote))
-            (:updated-at notes) => updated-at)
-          (count (s/get-revisions r/slug :finances)) => 2)
+          (fact "updates existing revision when the update of the section is by the same author & is under the time limit"
+            (check/delay-secs 1) ; not long enough to trigger a new revision
+            (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)]
+              (:author section) => (contains (common/author-for-user r/coyote))
+              (:data section) => (:data r/finances-section-2)
+              (:title section) => (:title r/finances-section-2)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? created-at updated-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 1)))
 
-        (future-fact "creates a new revision when the update of the section's note is by a different author")
+      (with-state-changes [(before :facts (s/put-section conn r/slug :finances r/finances-notes-section-1 r/coyote))]
 
-        (future-fact "creates a new revision when the update of the section's note is over the time limit")
+        (facts "when the prior revision of the section DOES have notes"
 
-        (fact "updates the existing revision when the update of the section & its note were by the same author &
+          (fact "creates a new revision when the update of the section DOESN'T have a note"
+            (s/put-section conn r/slug :finances r/finances-section-2 r/coyote)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)]
+              (:author section) => (contains (common/author-for-user r/coyote))
+              (:data section) => (:data r/finances-section-2)
+              (:title section) => (:title r/finances-section-2)
+              (:notes section) => nil
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (= updated-at created-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 2)
+
+          (fact "creates a new revision when the update of the section is by a different author"
+            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/camus)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)
+                  notes (:notes section)]
+              (:author section) => (contains (common/author-for-user r/camus))
+              (:data section) => (:data r/finances-notes-section-2)
+              (:title section) => (:title r/finances-notes-section-2)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (= updated-at created-at) => true
+              (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
+              (:author notes) => (contains (common/author-for-user r/camus))
+              (:updated-at notes) => updated-at)
+            (count (s/get-revisions conn r/slug :finances)) => 2)
+
+          (fact "creates a new revision when the update of the section is over the time limit"
+            (db/postdate conn r/slug :finances) ; long enough ago to trigger a new revision
+            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)
+                  notes (:notes section)]
+              (:author section) => (contains (common/author-for-user r/coyote))
+              (:data section) => (:data r/finances-notes-section-2)
+              (:title section) => (:title r/finances-notes-section-2)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (= created-at updated-at) => true
+              (:body notes) => (get-in r/finances-notes-section-2 [:notes :body])
+              (:author notes) => (contains (common/author-for-user r/coyote))
+              (:updated-at notes) => updated-at)
+            (count (s/get-revisions conn r/slug :finances)) => 2)
+
+          (future-fact "creates a new revision when the update of the section's note is by a different author")
+
+          (future-fact "creates a new revision when the update of the section's note is over the time limit")
+
+          (fact "updates the existing revision when the update of the section & its note were by the same author &
           are under the time limit"
-          (check/delay-secs 1) ; not long enough to trigger a new revision
-          (s/put-section r/slug :finances r/finances-notes-section-2 r/coyote)
-          (let [section (s/get-section r/slug :finances)
-                updated-at (:updated-at section)
-                created-at (:created-at section)]
-            (:author section) => (contains (common/author-for-user r/coyote))
-            (:data section) => (:data r/finances-notes-section-2)
-            (:title section) => (:title r/finances-notes-section-2)
-            (check/timestamp? updated-at) => true
-            (check/about-now? updated-at) => true
-            (check/before? created-at updated-at) => true)
-          (count (s/get-revisions r/slug :finances)) => 1)))))
+            (check/delay-secs 1) ; not long enough to trigger a new revision
+            (s/put-section conn r/slug :finances r/finances-notes-section-2 r/coyote)
+            (let [section (s/get-section conn r/slug :finances)
+                  updated-at (:updated-at section)
+                  created-at (:created-at section)]
+              (:author section) => (contains (common/author-for-user r/coyote))
+              (:data section) => (:data r/finances-notes-section-2)
+              (:title section) => (:title r/finances-notes-section-2)
+              (check/timestamp? updated-at) => true
+              (check/about-now? updated-at) => true
+              (check/before? created-at updated-at) => true)
+            (count (s/get-revisions conn r/slug :finances)) => 1))))))


### PR DESCRIPTION
trello card: https://trello.com/c/ixDW0KE3/47-switch-config-startup-shutdown-to-component

This PR refactors all code to have state passed explicitly, utilizing the component library to build/destroy this state.

Doing this refactoring it became painfully apparent how global state was spread over this codebase. In some places a database connection needs to be passed down very far. Ultimately this code should be refactored to get the required DB-originating data earlier in the callstack but I think that's outside of the  scope of this PR.

Also there's very pervasive usage of `with-pool` in all the api namespaces which kind of sucks but I haven't yet found a way to wrap liberators `defresource` in something like `with-pool`. If you have an idea, let me know.

To test I think tests should cover 99% but probably some manual testing won't hurt either.

- [x] fix tests
- [x] update readme commands
