### PR TITLE
Update handling of Growth placeholder section

### DIFF
--- a/opt/samples/buffer.edn
+++ b/opt/samples/buffer.edn
@@ -197,31 +197,31 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total users"
+            :name "Users"
+            :description "Total number of registered users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "mau"
             :name "MAU"
+            :description "Monthly Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "dau"
-            :name "Avg DAU"
+            :name "DAU"
+            :description "Average Daily Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "arr"
             :name "ARR"
+            :description "Annual Recurring Revenue"
             :interval "monthly"
             :unit "currency"
-            :target "increase"
           }
         ]
 
@@ -534,31 +534,31 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total users"
+            :name "Users"
+            :description "Total number of registered users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "mau"
             :name "MAU"
+            :description "Monthly Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "dau"
             :name "Avg DAU"
+            :description "Average Daily Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "arr"
             :name "ARR"
+            :description "Annual Recurring Revenue"
             :interval "monthly"
             :unit "currency"
-            :target "increase"
           }
 
         ]
@@ -896,31 +896,31 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total users"
+            :name "Users"
+            :description "Total number of registered users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "mau"
             :name "MAU"
+            :description "Monthly Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "dau"
             :name "Avg DAU"
+            :description "Average Daily Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "arr"
             :name "ARR"
+            :description "Annual Recurring Revenue"
             :interval "monthly"
             :unit "currency"
-            :target "increase"
           }
         ]
         :data [
@@ -1296,31 +1296,31 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total users"
+            :name "Users"
+            :description "Total number of registered users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "mau"
             :name "MAU"
+            :description "Monthly Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "dau"
             :name "Avg DAU"
+            :description "Average Daily Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "arr"
             :name "ARR"
+            :description "Annual Recurring Revenue"
             :interval "monthly"
             :unit "currency"
-            :target "increase"
           }
         ]
         :data [
@@ -1735,31 +1735,31 @@
         :metrics [
           {
             :slug "total-registered-users"
-            :name "Total users"
+            :name "Users"
+            :description "Total number of registered users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "mau"
             :name "MAU"
+            :description "Monthly Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "dau"
             :name "Avg DAU"
+            :description "Average Daily Active Users"
             :interval "monthly"
             :unit "number"
-            :target "increase"
           }
           {
             :slug "arr"
             :name "ARR"
+            :description "Annual Recurring Revenue"
             :interval "monthly"
             :unit "currency"
-            :target "increase"
           }
         ]
         :data [

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -115,42 +115,52 @@
           "headline": "",
           "prompt": "Enter the most important growth metric for the stakeholders of your company. You'll be able
           to add more later.",
-          "metrics": [
+          "metrics": [],
+          "standard-metrics": [
             {
               "slug": "dau",
-              "name": "Daily active users"
+              "name": "DAU",
+              "description": "Average Daily Active Users"
             },
             {
               "slug": "mau",
-              "name": "Monthly active users"
+              "name": "MAU",
+              "description": "Monthly Active Users"
             },
             {
               "slug": "wau",
-              "name": "Weekly active users"
+              "name": "WAU",
+              "description": "Weekly Active Users"
             },
             {
               "slug": "mrr",
-              "name": "Monthly recurring revenue"
+              "name": "MRR",
+              "description": "Monthly Recurring Revenue"
             },
             {
               "slug": "arr",
-              "name": "Annual recurring revenue"
+              "name": "ARR",
+              "description": "Annual Recurring Revenue"
             },
             {
               "slug": "subscribers",
-              "name": "Subscribers"
+              "name": "Subscribers",
+              "description": "Total active subscribers"
             },
             {
-              "slug": "subscribers",
-              "name": "Registrations"
+              "slug": "registrations",
+              "name": "Registrations",
+              "description": "Total registered users"
             },
             {
               "slug": "followers",
-              "name": "Followers"
+              "name": "Followers",
+              "description": "Total active followers"
             },
             {
               "slug": "views",
-              "name": "Views"
+              "name": "Views",
+              "description": "Total page views"
             }
           ],
           "intervals": [
@@ -170,10 +180,6 @@
               "unit": "%",
               "name": "%"
             }
-          ],
-          "goal": [
-            "increase",
-            "decrease"
           ],
           "note": "Provide context about recent growth with a note.",
           "icon": "chart-growth",

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -19,7 +19,7 @@
   Properties of the `sections.json` section placeholder data that are NOT valid properties of a section, but are
   simply meta-data for the UI.
   "
-  #{:core :prompt :section-name :standard-metrics :units :intervals})
+  #{:core :prompt :standard-metrics :units :intervals})
 ;; ----- Utility functions -----
 
 (defn- clean

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -96,10 +96,12 @@
   (reduce (fn [s sec]
             (assoc s
                    (:section-name sec)
-                   (-> sec
-                       (assoc :company-slug company-slug)
-                       (assoc :placeholder true)
-                       (dissoc :name))))
+                   (apply dissoc 
+                      (-> sec
+                        (assoc :company-slug company-slug)
+                        (assoc :placeholder true)
+                        (dissoc :name))
+                      metadata-properties)))
           {}
           (filter :core common/sections)))
 

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -14,6 +14,12 @@
   "Properties of a resource that can't be specified during a create and are ignored during an update."
   #{:slug :org-id :categories})
 
+(def metadata-properties
+  "
+  Properties of the `sections.json` section placeholder data that are NOT valid properties of a section, but are
+  simply meta-data for the UI.
+  "
+  #{:core :prompt :section-name :standard-metrics :units :intervals})
 ;; ----- Utility functions -----
 
 (defn- clean
@@ -112,7 +118,9 @@
         missing-section-names (->> sections (map keyword) (remove #(get company %)))
         missing-sections      (map common/section-by-name missing-section-names)
         ;; add :placeholder flag and remove :core flag
-        placeholder-sections (->> missing-sections (map #(dissoc % :core)) (map #(assoc % :placeholder true)))]
+        placeholder-sections (->> missing-sections
+                                (map #(apply dissoc % metadata-properties))
+                                (map #(assoc % :placeholder true)))]
     (merge company (zipmap missing-section-names placeholder-sections))))
 
 (defn add-prior-sections


### PR DESCRIPTION
https://trello.com/c/ro7Miff6

Review with https://github.com/open-company/open-company-web/pull/105

To test:

- [x] Reimport your data so you have no SU's
- [x] Look at the API response to /buffer/sections/new, should see it has a blank `:metrics` array and the standard metrics are now in `:standard-metrics` and they have descriptions.
- [x] Create a new company, look at the API response to `/<company>`, you should see the Growth placeholder section has an empty `:metrics` array and no `:interval` or `:units` array. Before this would have a full `:metrics` array and these other keys.
- [ ] Add a new Growth topic to a company that never had one, placeholder should look the same as described above.
- [x] Import Buffer. It should import OK, and the Growth topic data should have descriptions in it.