### PR TITLE
remove printing of connection object

### DIFF
--- a/src/open_company/api/entry.clj
+++ b/src/open_company/api/entry.clj
@@ -36,9 +36,7 @@
   :handle-not-acceptable (fn [_] (common/only-accept 406 "application/json"))
   :handle-unsupported-media-type (fn [_] (common/only-accept 415 "application/json"))
 
-  :handle-ok (fn [ctx]
-               (prn conn)
-               (render-entry conn ctx))
+  :handle-ok (fn [ctx] (render-entry conn ctx))
 
   :handle-options (common/options-response [:options :get]))
 

--- a/src/open_company/components.clj
+++ b/src/open_company/components.clj
@@ -11,7 +11,6 @@
           server  (httpkit/run-server handler options)]
       (assoc component :server server)))
   (stop [component]
-    ;; (prn component)
     (if-not server
       component
       (do


### PR DESCRIPTION
trello card: https://trello.com/c/hO9YdZCn/391-db-pool-output

**To test:** Deploy/run locally and verify there are no messages like these printed
```
#object[clojure.lang.Atom 0x6ad5e42 {:status :ready, :val {:client << stream: {:type "splice", :sink {:type "netty", :closed? false, :sink? true, :connection {:local-address "/127.0.0.1:62120", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :outbound}}, :source {:pending-puts 0, :drained? false, :buffer-size 0, :permanent? false, :type "netty", :sink? true, :closed? false, :pending-takes 1, :buffer-capacity 0, :connection {:local-address "/127.0.0.1:62120", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :inbound}, :direction :inbound, :source? true}} >>, :db "open_company_qa", :start-query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x4e1610b4 "clojure.core.async.impl.channels.ManyToManyChannel@4e1610b4"], :query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x6b2f43d0 "clojure.core.async.impl.channels.ManyToManyChannel@6b2f43d0"], :results {}, :cursors {}, :async? false, :token 6}}]
#object[clojure.lang.Atom 0x69187623 {:status :ready, :val {:client << stream: {:type "splice", :sink {:type "netty", :closed? false, :sink? true, :connection {:local-address "/127.0.0.1:62119", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :outbound}}, :source {:pending-puts 0, :drained? false, :buffer-size 0, :permanent? false, :type "netty", :sink? true, :closed? false, :pending-takes 1, :buffer-capacity 0, :connection {:local-address "/127.0.0.1:62119", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :inbound}, :direction :inbound, :source? true}} >>, :db "open_company_qa", :start-query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x52b6a0c "clojure.core.async.impl.channels.ManyToManyChannel@52b6a0c"], :query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x7b4649ad "clojure.core.async.impl.channels.ManyToManyChannel@7b4649ad"], :results {}, :cursors {}, :async? false, :token 15}}]
#object[clojure.lang.Atom 0x69187623 {:status :ready, :val {:client << stream: {:type "splice", :sink {:type "netty", :closed? false, :sink? true, :connection {:local-address "/127.0.0.1:62119", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :outbound}}, :source {:pending-puts 0, :drained? false, :buffer-size 0, :permanent? false, :type "netty", :sink? true, :closed? false, :pending-takes 1, :buffer-capacity 0, :connection {:local-address "/127.0.0.1:62119", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :inbound}, :direction :inbound, :source? true}} >>, :db "open_company_qa", :start-query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x52b6a0c "clojure.core.async.impl.channels.ManyToManyChannel@52b6a0c"], :query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x7b4649ad "clojure.core.async.impl.channels.ManyToManyChannel@7b4649ad"], :results {}, :cursors {}, :async? false, :token 15}}]
#object[clojure.lang.Atom 0x6ae6a4d6 {:status :ready, :val {:client << stream: {:type "splice", :sink {:type "netty", :closed? false, :sink? true, :connection {:local-address "/127.0.0.1:62123", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :outbound}}, :source {:pending-puts 0, :drained? false, :buffer-size 0, :permanent? false, :type "netty", :sink? true, :closed? false, :pending-takes 1, :buffer-capacity 0, :connection {:local-address "/127.0.0.1:62123", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :inbound}, :direction :inbound, :source? true}} >>, :db "open_company_qa", :start-query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x40e56ec7 "clojure.core.async.impl.channels.ManyToManyChannel@40e56ec7"], :query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x1ec007dd "clojure.core.async.impl.channels.ManyToManyChannel@1ec007dd"], :results {}, :cursors {}, :async? false, :token 15}}]
#object[clojure.lang.Atom 0x6ad5e42 {:status :ready, :val {:client << stream: {:type "splice", :sink {:type "netty", :closed? false, :sink? true, :connection {:local-address "/127.0.0.1:62120", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :outbound}}, :source {:pending-puts 0, :drained? false, :buffer-size 0, :permanent? false, :type "netty", :sink? true, :closed? false, :pending-takes 1, :buffer-capacity 0, :connection {:local-address "/127.0.0.1:62120", :remote-address "localhost/127.0.0.1:28015", :writable? true, :readable? true, :closed? false, :direction :inbound}, :direction :inbound, :source? true}} >>, :db "open_company_qa", :start-query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x4e1610b4 "clojure.core.async.impl.channels.ManyToManyChannel@4e1610b4"], :query-chan #object[clojure.core.async.impl.channels.ManyToManyChannel 0x6b2f43d0 "clojure.core.async.impl.channels.ManyToManyChannel@6b2f43d0"], :results {}, :cursors {}, :async? false, :token 16}}]
```