### PR TITLE
Category / SU update

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ Reorder a company's sections with cURL:
 
 ```console
 curl -i -X PATCH \
--d '{"sections": {"progress": ["growth", "team", "product", "challenges", "update"], "company": ["values", "mission"], "financial": ["finances"]}}' \
+-d '{"sections": {"progress": ["growth", "team", "product", "challenges", "update", "finances"], "company": ["values", "mission"]}}' \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
@@ -389,7 +389,7 @@ Remove sections from a company with cURL:
 
 ```console
 curl -i -X PATCH \
--d '{"sections": {"progress": ["growth", "team", "update"], "company": ["values"], "financial": []}}' \
+-d '{"sections": {"progress": ["growth", "team", "update"], "company": ["values"]}}' \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \
@@ -401,7 +401,7 @@ Add a section to the company with cURL:
 
 ```console
 curl -i -X PATCH \
--d '{"sections": {"progress": ["growth", "customer-service", "team", "update"], "company": ["values"], "financial": []}}' \
+-d '{"sections": {"progress": ["growth", "customer-service", "team", "update"], "company": ["values"]}}' \
 --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoiMTIzNDU2IiwibmFtZSI6ImNveW90ZSIsInJlYWwtbmFtZSI6IldpbGUgRS4gQ295b3RlIiwiYXZhdGFyIjoiaHR0cDpcL1wvd3d3LmVtb3RpY29uc3dhbGxwYXBlcnMuY29tXC9hdmF0YXJcL2NhcnRvb25zXC9XaWxleS1Db3lvdGUtRGF6ZWQuanBnIiwiZW1haWwiOiJ3aWxlLmUuY295b3RlQGFjbWUuY29tIiwib3duZXIiOmZhbHNlLCJhZG1pbiI6ZmFsc2UsIm9yZy1pZCI6Ijk4NzY1In0.HwqwEijPYDXTLdnL0peO8_KEtj379s4P5oJyv06yhfU" \
 --header "Accept: application/vnd.open-company.company.v1+json" \
 --header "Accept-Charset: utf-8" \

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Then enter these commands one-by-one, noting the output:
 (company/create-company!
   conn
   (company/->company {:name "Buffer"
-                      :slug (slug/find-available-slug "Blank Inc." (company/taken-slugs conn))
+                      :slug (slug/find-available-slug "Buffer" (company/taken-slugs conn))
                       :currency "USD"
                       :description "A better way to share on social media."
                       :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"

--- a/README.md
+++ b/README.md
@@ -284,9 +284,7 @@ Then enter these commands one-by-one, noting the output:
   (su/->stakeholder-update
     conn
     (company/get-company conn "open")
-    {:title "OpenCompany"
-     :intro {:body "This is what is up."}
-     :outro {:body "Peace out!"}
+    {:title "OpenCompany Update"
      :sections ["update" "finances"]}
     author))
 

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ Then enter these commands one-by-one, noting the output:
     conn
     (company/get-company conn "open")
     {:title "OpenCompany Update"
-     :sections ["update" "finances"]}
+     :sections ["finances"]}
     author))
 
 ;; delete a company

--- a/REPL_notes.clj
+++ b/REPL_notes.clj
@@ -40,7 +40,7 @@
 (with-open [c (apply r/connect conn)]
   (-> (r/table "companies")
       (r/get "prompt")
-      (r/update {:stakeholder-update {:title "" :intro {:body ""} :outro {:body ""} :sections []}})
+      (r/update {:stakeholder-update {:title "" :sections []}})
       (r/run c)))
 
 (with-open [c (apply r/connect conn)]

--- a/docs/stakeholder-updates.md
+++ b/docs/stakeholder-updates.md
@@ -4,7 +4,7 @@ The API for Stakeholder Updates supports the following:
 
 * initial selected sections for a new company
 * data for the live view
-* edit the live title/intro/outro
+* edit the title
 * add/remove/reorder live sections
 * create/share a stakeholder update (turns live view into a saved prior) 
 * list of prior updates
@@ -21,64 +21,12 @@ format:
 ```
 :stakeholder-update {
   :title ""
-  :intro {
-    :body ""
-  }
-  :outro {
-    :body ""
-  }
   :sections ["name" "name"]
 }
 ```
 
-Or with an intro:
-
-```
-:stakeholder-update {
-  :title "Our Great Update"
-  :intro {
-    :body "Some text."
-    :updated-at: "ISO8601"
-    "author" : {
-      "image" : "Avatar URL",
-      "name" : "Full Name",
-      "user-id" : "Slack ID"
-    }
-  :outro {
-    :body ""
-  }
-  :sections ["name" "name"]
-}
-```
-
-And on outro:
-
-```
-:stakeholder-update {
-  :title "Our Great Update"
-  :intro {
-    :body "Some text."
-    :updated-at: "ISO8601"
-    "author" : {
-      "image" : "Avatar URL",
-      "name" : "Full Name",
-      "user-id" : "Slack ID"
-    }
-  :outro {
-    :body "Other text."
-    :updated-at: "ISO8601"
-    "author" : {
-      "image" : "Avatar URL",
-      "name" : "Full Name",
-      "user-id" : "Slack ID"
-    }
-  }
-  :sections ["name" "name"]
-}
-```
-
-A "live" or "pending" stakeholder update can always be shown by showing the title, intro message (if there is one) and
-the latest contents of each of the included sections in the specified order, then the outro message (if there is one).
+A "live" or "pending" stakeholder update can always be shown by showing the title and
+the latest contents of each of the included sections in the specified order.
 When displaying a stakeholder update, any section that's in the stakeholder update but is not currently in the
 dashboard (shouldn't actually happen) should be skipped. Any section that's still a placeholder should be skipped.
 
@@ -130,13 +78,10 @@ The response (assuming a user auth'd to the company, otherwise DELETE links will
     "stakeholder-updates" : [ {
       "title" : "December Update",
       "slug" : "december-update-4a6f",
-      "intro": {
-        "body": "It's been a helluva month!",
-        "author" : {
-          "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
-          "name" : "Joel Gascoigne",
-          "user-id" : "123456"
-        }
+      "author" : {
+        "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
+        "name" : "Joel Gascoigne",
+        "user-id" : "123456"
       },
       "created-at": "2016-01-02T12:28:20.454Z",
       "links" : [ 
@@ -155,13 +100,10 @@ The response (assuming a user auth'd to the company, otherwise DELETE links will
     }, {
       "title" : "January Update",
       "slug" : "january-update-65b5",
-      "intro": {
-        "body": "It's been a helluva month!",
-        "author" : {
-          "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
-          "name" : "Joel Gascoigne",
-          "user-id" : "123456"
-        }
+      "author" : {
+        "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
+        "name" : "Joel Gascoigne",
+        "user-id" : "123456"
       },
       "created-at": "2016-03-08T12:28:20.454Z",
       "links" : [
@@ -180,13 +122,10 @@ The response (assuming a user auth'd to the company, otherwise DELETE links will
     }, {
       "title" : "February Update",
       "slug" : "february-update-d786",
-      "intro": {
-        "body": "It's been a helluva month!",
-        "author" : {
-          "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
-          "name" : "Joel Gascoigne",
-          "user-id" : "123456"
-        }
+      "author" : {
+        "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
+        "name" : "Joel Gascoigne",
+        "user-id" : "123456"
       },
       "created-at": "2016-03-12T12:28:20.454Z",
       "links" : [
@@ -255,13 +194,10 @@ The response:
   "created-at" : "2016-02-12T12:28:20.454Z",
   "title": "January Update",
   "sections" : ["product", "team", "help"],
-  "intro": {
-    "body": "It's been a helluva month!",
-    "author" : {
-      "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
-      "name" : "Joel Gascoigne",
-      "user-id" : "123456"
-    }
+  "author" : {
+    "image" : "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g",
+    "name" : "Joel Gascoigne",
+    "user-id" : "123456"
   },
   "product" : {
     "updated-at" : "2015-11-20T08:00:46.000Z",

--- a/opt/samples/bago.edn
+++ b/opt/samples/bago.edn
@@ -16,8 +16,7 @@
       :image "https://secure.gravatar.com/avatar/98b5456ea1c562024f41501ffd7bc3c6.jpg?s=192&d=https%3A%2F%2Fslack.global.ssl.fastly.net%2F7fa9%2Fimg%2Favatars%2Fava_0022-192.png"
     }
     :sections {
-      :progress ["growth"]
-      :financial ["finances"]
+      :progress ["growth" "finances"]
       :company []
     }
     :stakeholder-update {

--- a/opt/samples/bago.edn
+++ b/opt/samples/bago.edn
@@ -21,14 +21,6 @@
     }
     :stakeholder-update {
       :title "Bago's Updates"
-      :intro {
-        :body "Bago is AOK."
-        :updated-at "2015-07-13T12:59:28.000Z"
-      }
-      :outro {
-        :body "AOK is Bago."
-        :updated-at "2015-07-13T12:59:28.000Z"
-      }
       :sections ["growth" "finances"]
     }
   }

--- a/opt/samples/blank.edn
+++ b/opt/samples/blank.edn
@@ -15,7 +15,6 @@
     }
     :sections {
       :progress []
-      :financial []
       :company []
     }
     :stakeholder-update {

--- a/opt/samples/blank.edn
+++ b/opt/samples/blank.edn
@@ -19,12 +19,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections []
     }
   }

--- a/opt/samples/buffer.edn
+++ b/opt/samples/buffer.edn
@@ -22,12 +22,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }      
       :sections ["growth" "finances" "team" "product" "customer-service" "marketing" "help"]
     }
   }
@@ -2144,128 +2138,61 @@
     ;; June update https://open.bufferapp.com/buffer-june-2015/
     {
       :title "Buffer in June 2015: Fastest-Ever Team Growth, $6.6M ARR"
-      :intro {
-        :body "<p>We’re officially halfway through the year. Very excited to share the latest update for Buffer.</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
-      :outro {
-        :body "
-          <h3>Over to you</h3>
-          <p>Thanks for being part of our journey. If you have any questions or thoughts, I’d be keen to hear them.</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
       :sections ["growth" "finances" "help" "team" "product" "update"]
       :timestamp "2015-07-13T12:59:35.000Z"
+      :author {
+        :name "Joel Gascoigne"
+        :user-id "123456"
+        :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
+      }
     }
 
     ;; July update https://open.bufferapp.com/buffer-july-2015-investors-report/
     {
       :title "Buffer Investors’ Report: $6.86M ARR, Sixth Retreat, New ‘Areas’ Structure"
-      :intro {
-        :body "<p>I’m excited to share the latest update of everything going on at Buffer.</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
-      :outro {
-        :body "
-          <p>Thanks again for being part of the Buffer journey. We’d be excited to hear have any thoughts you have for us!</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
       :sections ["growth" "finances" "help" "team" "update" "product"]
       :timestamp "2015-08-13T16:26:47.000Z"
+      :author {
+        :name "Joel Gascoigne"
+        :user-id "123456"
+        :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
+      }
     }
 
     ;; August Update https://open.bufferapp.com/investors-report-august-2015/
     {
       :title "Buffer in August: $7.49M ARR, Buffer for Video, Continued Growth"
-      :intro {
-        :body "<p>Here are all the latest numbers and updates from all corners of what’s going on in the Buffer team!</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
-      :outro {
-        :body "
-        <p>Thanks for your help and support :-)</p>
-        <p>Best,</p>
-        <p>Joel Gascoigne</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
       :sections ["growth" "finances" "team" "product" "customer-service" "help"]
       :timestamp "2015-09-18T18:33:45.000Z"
+      :author {
+        :name "Joel Gascoigne"
+        :user-id "123456"
+        :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
+      }
     }
 
     ;; September Update https://open.buffer.com/the-50-teammates-milestone-buffers-september-investors-report/
     {
       :title "50 Teammates, 17 Open Roles, New Calendar View & More: Buffer’s September Update"
-      :intro {
-        :body "<p>Here are all the latest insights from the Buffer team in September.</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
-      :outro {
-        :body "
-        <p><b>We’ll have lots more to report next month. Thanks for your support!</b></p>
-        <p>Are there any questions about our team or growth that you’d like to know? We’d be happy to answer them!</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
       :sections ["update" "growth" "finances" "team" "product" "customer-service" "marketing"]
       :timestamp "2015-10-23T11:21:42.000Z"
+      :author {
+        :name "Joel Gascoigne"
+        :user-id "123456"
+        :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
+      }
     }
 
     ;; October Update https://open.buffer.com/buffer-october-2015/
     {
       :title "Buffer in October: $7.8M Annual Revenue, Pablo 2.0 Launch, Customer Happiness at 95%"
-      :intro {
-        :body "
-        <p>October was an unusual month for us, numbers-wise, as a result of us moving from 7-day to 30- day trials
-        of Buffer for Business. Here’s more about that and everything else going on at Buffer in our October 2015
-        investors’ report.</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
-      :outro {
-        :body "
-        <p>Thanks again for being part of the Buffer journey!</p>"
-        :author {
-          :name "Joel Gascoigne"
-          :user-id "123456"
-          :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
-        }
-      }
       :sections ["growth" "finances" "team" "product" "customer-service" "marketing" "help"]
       :timestamp "2015-11-20T08:00:47.000Z"
+      :author {
+        :name "Joel Gascoigne"
+        :user-id "123456"
+        :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
+      }
     }
   ]
 }

--- a/opt/samples/buffer.edn
+++ b/opt/samples/buffer.edn
@@ -17,9 +17,8 @@
       :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
     }
     :sections {
-      :progress ["update" "growth" "team" "product" "marketing" "customer-service"]
-      :financial ["finances"]
-      :company ["help" "diversity" "values"]
+      :progress ["update" "growth" "team" "product" "marketing" "customer-service" "finances" "help"]
+      :company ["diversity" "values"]
     }
     :stakeholder-update {
       :title ""

--- a/opt/samples/ent.edn
+++ b/opt/samples/ent.edn
@@ -21,12 +21,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections ["finances"]
     }
   }

--- a/opt/samples/ent.edn
+++ b/opt/samples/ent.edn
@@ -16,8 +16,7 @@
       :image "http://0.gravatar.com/avatar/c4a85c55f8cbe37706c309b77855a951?s=32&d=&r=G"
     }
     :sections {
-      :progress []
-      :financial ["finances"]
+      :progress ["finances"]
       :company []
     }
     :stakeholder-update {

--- a/opt/samples/new.edn
+++ b/opt/samples/new.edn
@@ -21,12 +21,6 @@
     }    
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections ["finances"]
     }
   }

--- a/opt/samples/new.edn
+++ b/opt/samples/new.edn
@@ -16,8 +16,7 @@
       :image "http://2.gravatar.com/avatar/22bd03ace6f176bfe0c593650bcf45d8?s=48&d=&r=G"
     }
     :sections {
-      :progress []
-      :financial ["finances"]
+      :progress ["finances"]
       :company []
     }    
     :stakeholder-update {

--- a/opt/samples/pied-piper.edn
+++ b/opt/samples/pied-piper.edn
@@ -22,12 +22,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections ["update" "growth" "finances" "team" "product" "marketing" "customer-service" "help"]
     }
   }

--- a/opt/samples/pied-piper.edn
+++ b/opt/samples/pied-piper.edn
@@ -17,8 +17,7 @@
       :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
     }
     :sections {
-      :progress ["update" "growth" "team" "product" "marketing" "customer-service" "help"]
-      :financial ["finances"]
+      :progress ["update" "growth" "team" "product" "marketing" "customer-service" "help" "finances"]
       :company ["diversity" "values"]
     }
     :stakeholder-update {

--- a/opt/samples/read-only.edn
+++ b/opt/samples/read-only.edn
@@ -21,12 +21,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections ["update" "help" "team" "product" "marketing" "customer-service" "growth" "finances"]
     }
   }

--- a/opt/samples/read-only.edn
+++ b/opt/samples/read-only.edn
@@ -16,8 +16,7 @@
       :image "https://secure.gravatar.com/avatar/46c1c756f36549c2dea0253e1e025053?s=96&d=mm&r=g"
     }
     :sections {
-      :progress ["update" "growth" "team" "product" "marketing" "customer-service" "help"]
-      :financial ["finances"]
+      :progress ["update" "growth" "team" "product" "marketing" "customer-service" "help" "finances"]
       :company ["diversity" "values"]
     }
     :stakeholder-update {

--- a/opt/samples/simple.edn
+++ b/opt/samples/simple.edn
@@ -21,12 +21,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections ["growth" "finances"]
     }
   }

--- a/opt/samples/simple.edn
+++ b/opt/samples/simple.edn
@@ -16,8 +16,7 @@
       :image "https://secure.gravatar.com/avatar/f5b8fc1affa266c8072068f811f63e04.jpg?s=192&d=https%3A%2F%2Fslack.global.ssl.fastly.net%2F7fa9%2Fimg%2Favatars%2Fava_0020-192.png"
     }
     :sections {
-      :progress ["growth"]
-      :financial ["finances"]
+      :progress ["growth" "finances"]
       :company []
     }
     :stakeholder-update {

--- a/opt/samples/uni.edn
+++ b/opt/samples/uni.edn
@@ -17,7 +17,6 @@
     }
     :sections {
       :progress ["update"]
-      :financial []
       :company []
     }
     :stakeholder-update {

--- a/opt/samples/uni.edn
+++ b/opt/samples/uni.edn
@@ -21,12 +21,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections ["update"]
     }
   }

--- a/opt/samples/yoyo.edn
+++ b/opt/samples/yoyo.edn
@@ -21,12 +21,6 @@
     }
     :stakeholder-update {
       :title ""
-      :intro {
-        :body ""
-      }
-      :outro {
-        :body ""
-      }
       :sections ["finances"]
     }
   }

--- a/opt/samples/yoyo.edn
+++ b/opt/samples/yoyo.edn
@@ -17,7 +17,6 @@
     }
     :sections {
       :progress ["finances"]
-      :financial []
       :company []
     }
     :stakeholder-update {

--- a/src/open_company/api/stakeholder_updates.clj
+++ b/src/open_company/api/stakeholder_updates.clj
@@ -39,7 +39,7 @@
 
 (defn- list-stakeholder-updates [conn company-slug]
   (if-let* [company (company-res/get-company conn company-slug)
-            su-list (su-res/list-stakeholder-updates conn company-slug [:slug :title :intro])]
+            su-list (su-res/list-stakeholder-updates conn company-slug [:slug :title])]
     {:company company :stakeholder-updates su-list}
     false))
 

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -40,18 +40,6 @@
         },
 
         {
-          "section-name": "privacy",
-          "title": "Data Privacy",
-          "description": "Company policy on customer information privacy",
-          "headline": "",
-          "body": "How does the company use customer data? What regulations such as US HIPAA or European GDPR
-          apply to the company? What agreements exist with customers about their data? What
-          do these agreements say in Plain English?",
-          "icon": "lock",
-          "core": false
-        },
-
-        {
           "section-name": "competition",
           "title": "Competition",
           "headline": "",
@@ -60,27 +48,8 @@
           what are the other major external threats to your business?",
           "icon": "shark",
           "core": false
-        },
-
-        {
-          "section-name": "help",
-          "title": "How You Can Help",
-          "headline": "",
-          "description": "Ask your company stakeholders for help and ideas",
-          "body": "Where do you need the most help from your team and investors? Be specific.",
-          "icon": "bulb-63",
-          "core": false
-        },
-
-        {
-          "section-name": "kudos",
-          "title": "Kudos",
-          "headline": "",
-          "description": "Celebrate great actions that helped the company",
-          "body": "Who went above and beyond to help the company? What did they do?",
-          "icon": "award-48",
-          "core": false
         }
+
       ]
     },
     {
@@ -283,14 +252,27 @@
           "body": "Did you close any notable deals / partnerships? What opportunities are in the pipeline?",
           "icon": "handshake",
           "core": false
-        }
+        },
 
-      ]
-    },
-    {
-      "name": "financial",
-      "title": "Financial",
-      "sections": [
+        {
+          "section-name": "help",
+          "title": "How You Can Help",
+          "headline": "",
+          "description": "Ask your company stakeholders for help and ideas",
+          "body": "Where do you need the most help from your team and investors? Be specific.",
+          "icon": "bulb-63",
+          "core": false
+        },
+
+        {
+          "section-name": "kudos",
+          "title": "Kudos",
+          "headline": "",
+          "description": "Celebrate great actions that helped the company",
+          "body": "Who went above and beyond to help the company? What did they do?",
+          "icon": "award-48",
+          "core": false
+        },
 
         {
           "section-name": "finances",

--- a/src/open_company/representations/stakeholder_update.clj
+++ b/src/open_company/representations/stakeholder_update.clj
@@ -28,7 +28,6 @@
     {
       :title (:title update)
       :slug slug
-      :intro (:intro update)
       :created-at (:created-at update)
       :links (if authorized [su-link (common/delete-link (stakeholder-update-url company-url slug))] [su-link])
     }))

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -69,8 +69,6 @@
 
 (def empty-stakeholder-update {
   :title ""
-  :intro {:body ""} 
-  :outro {:body ""}
   :sections []})
 
 ;; ----- Schemas -----
@@ -101,11 +99,6 @@
    (schema/optional-key :author) Author
    schema/Keyword schema/Any})
 
-(def UpdateSection {
-  :body schema/Str
-  (schema/optional-key :updated-at) schema/Str
-  (schema/optional-key :author) Author}) ; user that last modified the intro
-
 (def InlineSections
   (into {} (for [sn section-names] [(schema/optional-key sn) Section])))
 
@@ -120,8 +113,6 @@
           :categories (schema/pred #(clojure.set/subset? (set (map keyword %)) (set category-names)))
           :stakeholder-update {
             :title schema/Str
-            :intro UpdateSection
-            :outro UpdateSection
             :sections [SectionName]
           }
           (schema/optional-key :home-page) schema/Str
@@ -142,8 +133,6 @@
           (schema/optional-key :logo-height) schema/Int          
           :title schema/Str
           :sections [SectionName]
-          :intro UpdateSection
-          :outro UpdateSection
           :created-at schema/Str
           :author Author} ; user that created the update
         InlineSections))

--- a/src/open_company/resources/stakeholder_update.clj
+++ b/src/open_company/resources/stakeholder_update.clj
@@ -53,8 +53,6 @@
     (assoc :company-slug (:slug company))
     (merge (select-keys company [:name :description :logo :logo-width :logo-height])) ; freeze some props of company
     (update :title #(or % ""))
-    (update :intro #(or % {:body ""}))
-    (update :outro #(or % {:body ""}))
     (assoc :author (common/author-for-user user))
     (assoc :created-at timestamp)
     (sections-for conn))))

--- a/src/open_company/util/sample_data.clj
+++ b/src/open_company/util/sample_data.clj
@@ -20,7 +20,7 @@
   [conn company-slug company update]
   (let [title (:title update)
         as-of (:timestamp update)
-        author (get-in update [:intro :author])
+        author (:author update)
         message (str "stakeholder update '" title "' at " as-of " by " (:name author) ".")]
     (println (str "Creating " message))
     (if

--- a/test/open_company/integration/company/company_retrieval.clj
+++ b/test/open_company/integration/company/company_retrieval.clj
@@ -118,8 +118,7 @@
         (:org-id body) => nil ; verify no org-id
         (:categories body) => (map name common/category-names)
         (:sections body) =>
-          {:company ["diversity" "values"], :progress ["help" "update" "team" "finances
-          "]}
+          {:company ["diversity" "values"], :progress ["update" "finances" "team" "help"]}
         ;; verify section contents
         (:update body) => (contains r/text-section-1)
         (:finances body) => (contains r/finances-section-1)
@@ -139,7 +138,7 @@
             body (mock/body-from-response response)]
         (:status response) => 200
         (:sections body) =>
-          {:company ["diversity" "values"], :progress ["help" "update" "team" "finances"]}
+          {:company ["diversity" "values"], :progress ["update" "finances" "team" "help"]}
         ;; verify each section has only a self HATEOAS link
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (count (:links (body section-key))) => 1
@@ -155,7 +154,7 @@
             body (mock/body-from-response response)]
         (:status response) => 200
         (:sections body) =>
-          {:company ["diversity" "values"], :progress ["help" "update" "team" "finances"]}
+          {:company ["diversity" "values"], :progress ["update" "finances" "team" "help"]}
         ;; verify each section has only a self HATEOAS link
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (count (:links (body section-key))) => 1

--- a/test/open_company/integration/company/company_retrieval.clj
+++ b/test/open_company/integration/company/company_retrieval.clj
@@ -118,7 +118,8 @@
         (:org-id body) => nil ; verify no org-id
         (:categories body) => (map name common/category-names)
         (:sections body) =>
-          {:company ["help" "diversity" "values"], :financial ["finances"], :progress ["update" "team"]}
+          {:company ["diversity" "values"], :progress ["help" "update" "team" "finances
+          "]}
         ;; verify section contents
         (:update body) => (contains r/text-section-1)
         (:finances body) => (contains r/finances-section-1)
@@ -138,7 +139,7 @@
             body (mock/body-from-response response)]
         (:status response) => 200
         (:sections body) =>
-          {:company ["help" "diversity" "values"], :financial ["finances"], :progress ["update" "team"]}
+          {:company ["diversity" "values"], :progress ["help" "update" "team" "finances"]}
         ;; verify each section has only a self HATEOAS link
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (count (:links (body section-key))) => 1
@@ -154,7 +155,7 @@
             body (mock/body-from-response response)]
         (:status response) => 200
         (:sections body) =>
-          {:company ["help" "diversity" "values"], :financial ["finances"], :progress ["update" "team"]}
+          {:company ["diversity" "values"], :progress ["help" "update" "team" "finances"]}
         ;; verify each section has only a self HATEOAS link
         (doseq [section-key (map keyword (flatten (vals (:sections body))))]
           (count (:links (body section-key))) => 1

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -69,11 +69,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-<<<<<<< HEAD
                                    :progress ["update" "finances" "team" "help"]}))
-=======
-                                   :progress ["help" "update" "team" "finances"]}))
->>>>>>> 6dfda8307cb9a8e2efbf4ae69d5e1b9193625957
 
     (fact "with no JWToken"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -86,11 +82,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-<<<<<<< HEAD
                                    :progress ["update" "finances" "team" "help"]}))
-=======
-                                   :progress ["help" "update" "team" "finances"]}))
->>>>>>> 6dfda8307cb9a8e2efbf4ae69d5e1b9193625957
 
     (fact "with an organization that doesn't match the company"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -103,11 +95,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-<<<<<<< HEAD
                                    :progress ["update" "finances" "team" "help"]}))
-=======
-                                   :progress ["help" "update" "team" "finances"]}))
->>>>>>> 6dfda8307cb9a8e2efbf4ae69d5e1b9193625957
 
     (fact "with no company matching the company slug"
       (let [new-order {:company ["diversity" "values"]
@@ -119,11 +107,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-<<<<<<< HEAD
                                    :progress ["update" "finances" "team" "help"]})))
-=======
-                                   :progress ["help" "update" "team" "finances"]})))
->>>>>>> 6dfda8307cb9a8e2efbf4ae69d5e1b9193625957
 
   (facts "about section reordering"
 
@@ -131,11 +115,7 @@
     (let [db-company (company/get-company conn r/slug)]
       (:categories db-company) => categories
       (:sections db-company) => {:company ["diversity" "values"]
-<<<<<<< HEAD
                                  :progress ["update" "finances" "team" "help"]})
-=======
-                                 :progress ["help" "update" "team" "finances"]})
->>>>>>> 6dfda8307cb9a8e2efbf4ae69d5e1b9193625957
 
     (facts "when the new order is valid"
 

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -68,9 +68,8 @@
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:company ["help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]}))
+        (:sections db-company) => {:company ["diversity" "values"]
+                                   :progress ["help" "update" "team" "finances"]}))
 
     (fact "with no JWToken"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -82,9 +81,8 @@
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]}))
+        (:sections db-company) => {:company ["diversity" "values"]
+                                   :progress ["help" "update" "team" "finances"]}))
 
     (fact "with an organization that doesn't match the company"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -96,38 +94,33 @@
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]}))
+        (:sections db-company) => {:company ["diversity" "values"]
+                                   :progress ["help" "update" "team" "finances"]}))
 
     (fact "with no company matching the company slug"
       (let [new-order {:company ["diversity" "values"]
-                       :progress ["team" "update" "finances" "help"]
-                       :financial []}
+                       :progress ["team" "update" "finances" "help"]}
             response (mock/api-request :patch (company-rep/url "foo") {:body {:sections new-order}})]
         (:status response) => 404
         (:body response) => "")
       ;; verify the initial order is unchanged
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
-        (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                   :progress ["update" "team"]
-                                   :financial ["finances"]})))
+        (:sections db-company) => {:company ["diversity" "values"]
+                                   :progress ["help" "update" "team" "finances"]})))
 
   (facts "about section reordering"
 
     ;; verify the initial order
     (let [db-company (company/get-company conn r/slug)]
       (:categories db-company) => categories
-      (:sections db-company) => {:company [ "help" "diversity" "values"]
-                                 :progress ["update" "team"]
-                                 :financial ["finances"]})
+      (:sections db-company) => {:company ["diversity" "values"]
+                                 :progress ["help" "update" "team" "finances"]})
 
     (facts "when the new order is valid"
 
       (fact "the section order in the progress category can be gently adjusted"
-        (let [new-order {:progress ["team" "update" "help"]
-                         :financial ["finances"]
+        (let [new-order {:progress ["team" "update" "help" "finances"]
                          :company ["diversity" "values"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -136,8 +129,7 @@
           (:sections (company/get-company conn r/slug)) => new-order))
 
       (fact "the sections order in the progress category can be greatly adjusted"
-        (let [new-order {:progress ["help" "team" "update"]
-                         :financial ["finances"]
+        (let [new-order {:progress ["help" "team" "update" "finances"]
                          :company ["diversity" "values"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -146,8 +138,7 @@
           (:sections (company/get-company conn r/slug)) => new-order))
 
       (fact "the section order in the company category can be adjusted"
-        (let [new-order {:progress ["update" "team" "help"]
-                         :financial ["finances"]
+        (let [new-order {:progress ["update" "team" "help" "finances"]
                          :company ["values" "diversity"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -156,8 +147,7 @@
           (:sections (company/get-company conn r/slug)) => new-order))
 
       (fact "the section order in the progress and company category can both be adjusted at once"
-        (let [new-order {:progress ["help" "team" "update"]
-                         :financial ["finances"]
+        (let [new-order {:progress ["help" "team" "update" "finances"]
                          :company ["values" "diversity"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})]
           (:status response) => 200
@@ -173,8 +163,7 @@
           response (mock/api-request :post "/companies" {:body payload})
           company  (company/get-company conn slug)]
       ;; ensure all placeholder sections are in company
-      (:sections company) => {:progress ["update" "growth" "challenges" "team" "product"]
-                              :financial ["finances"]
+      (:sections company) => {:progress ["update" "growth" "challenges" "team" "product" "finances"]
                               :company ["mission" "values"]}
       (:growth company) => truthy
       (:challenges company) => truthy
@@ -182,8 +171,7 @@
       (:product company) => truthy
       (:mission company) => truthy
       (let [new-set {:company ["values"]
-                     :progress ["update" "finances" "help"]
-                     :financial []}
+                     :progress ["update" "finances" "help"]}
             response (mock/api-request :patch (company-rep/url slug) {:body {:sections new-set}})
             body     (mock/body-from-response response)
             company  (company/get-company conn slug)]
@@ -198,14 +186,12 @@
   (facts "about section removal"
 
     ;; verify the initial set of sections
-    (:sections (company/get-company conn r/slug)) => {:company ["help" "diversity" "values"]
-                                                 :progress ["update" "team"]
-                                                 :financial ["finances"]}
+    (:sections (company/get-company conn r/slug)) => {:company ["diversity" "values"]
+                                                 :progress ["help" "update" "team" "finances"]}
 
       (fact "a section can be removed from the progress category"
-        (let [new-set {:company ["help" "diversity" "values"]
-                       :progress ["update"]
-                       :financial ["finances"]}
+        (let [new-set {:company ["diversity" "values"]
+                       :progress ["help" "update" "finances"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
               body (mock/body-from-response response)
               db-company (company/get-company conn r/slug)]
@@ -227,9 +213,8 @@
           (:values db-company) => (contains r/text-section-1)))
 
       (fact "multiple sections can be removed from the progress category"
-        (let [new-set {:company ["help" "diversity" "values"]
-                       :progress []
-                       :financial ["finances"]}
+        (let [new-set {:company ["diversity" "values"]
+                       :progress ["help"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-set}})
               body (mock/body-from-response response)
               db-company (company/get-company conn r/slug)]
@@ -251,9 +236,8 @@
           (:values db-company) => (contains r/text-section-1)))
 
       (fact "a section can be removed from the company category"
-        (let [new-order {:company ["help" "diversity"]
-                         :progress ["update" "team"]
-                         :financial ["finances"]}
+        (let [new-order {:company ["diversity"]
+                         :progress ["help" "update" "team" "finances"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
               body (mock/body-from-response response)
               db-company (company/get-company conn r/slug)]
@@ -276,8 +260,7 @@
 
       (fact "sections can be removed from all the categories at once"
         (let [new-order {:company ["values"]
-                         :progress ["update" "help"]
-                         :financial []}
+                         :progress ["update" "help"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-order}})
               body (mock/body-from-response response)
               db-company (company/get-company conn r/slug)]
@@ -301,7 +284,7 @@
   (facts "about adding sections"
 
     (fact "that don't really exist"
-      (let [new-sections {:company [] :progress ["health"] :financial []}
+      (let [new-sections {:company [] :progress ["health"]}
             response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
             body (mock/body-from-response response)]
         (:status response) => 422))
@@ -309,7 +292,7 @@
     (facts "without any section content"
     
       (fact "that never existed"
-        (let [new-sections {:company [] :progress ["highlights"] :financial []}
+        (let [new-sections {:company [] :progress ["highlights"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
               body (mock/body-from-response response)
               resp-highlights (:highlights body)
@@ -326,7 +309,7 @@
           db-highlights => (contains placeholder)))
 
       (future-fact "that used to exist"
-        (let [new-sections {:company [] :progress [] :financial []}
+        (let [new-sections {:company [] :progress []}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
               body (mock/body-from-response response)
               db-company (company/get-company conn r/slug)]
@@ -336,7 +319,7 @@
           (:update body) => nil
           ; verify update not in the DB
           (:update db-company) => nil)
-        (let [new-sections {:company [] :progress ["update"] :financial []}
+        (let [new-sections {:company [] :progress ["update"]}
               response (mock/api-request :patch (company-rep/url r/slug) {:body {:sections new-sections}})
               body (mock/body-from-response response)
               db-company (company/get-company conn r/slug)]
@@ -349,9 +332,8 @@
 
     (facts "with section content"
 
-      (let [new-sections {:company ["help" "diversity" "values"]
-                            :progress ["update" "team" "kudos"]
-                            :financial ["finances"]}
+      (let [new-sections {:company ["diversity" "values"]
+                            :progress ["help" "update" "team" "kudos" "finances"]}
             kudos-placeholder (common-res/section-by-name "kudos")]
 
         (future-fact "with minimal content"

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -69,7 +69,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-                                   :progress ["help" "update" "team" "finances"]}))
+                                   :progress ["update" "finances" "team" "help"]}))
 
     (fact "with no JWToken"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -82,7 +82,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-                                   :progress ["help" "update" "team" "finances"]}))
+                                   :progress ["update" "finances" "team" "help"]}))
 
     (fact "with an organization that doesn't match the company"
       (let [new-order {:progress ["team" "update" "finances" "help"]
@@ -95,7 +95,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-                                   :progress ["help" "update" "team" "finances"]}))
+                                   :progress ["update" "finances" "team" "help"]}))
 
     (fact "with no company matching the company slug"
       (let [new-order {:company ["diversity" "values"]
@@ -107,7 +107,7 @@
       (let [db-company (company/get-company conn r/slug)]
         (:categories db-company) => categories
         (:sections db-company) => {:company ["diversity" "values"]
-                                   :progress ["help" "update" "team" "finances"]})))
+                                   :progress ["update" "finances" "team" "help"]})))
 
   (facts "about section reordering"
 
@@ -115,7 +115,7 @@
     (let [db-company (company/get-company conn r/slug)]
       (:categories db-company) => categories
       (:sections db-company) => {:company ["diversity" "values"]
-                                 :progress ["help" "update" "team" "finances"]})
+                                 :progress ["update" "finances" "team" "help"]})
 
     (facts "when the new order is valid"
 
@@ -187,7 +187,7 @@
 
     ;; verify the initial set of sections
     (:sections (company/get-company conn r/slug)) => {:company ["diversity" "values"]
-                                                 :progress ["help" "update" "team" "finances"]}
+                                                 :progress ["update" "finances" "team" "help"]}
 
       (fact "a section can be removed from the progress category"
         (let [new-set {:company ["diversity" "values"]
@@ -222,7 +222,7 @@
           (:sections body) => new-set
           (:update body) => nil
           (:team body) => nil
-          (:finances body) => (contains r/finances-section-1)
+          (:finances body) => nil
           (:help body) => (contains r/text-section-1)
           (:diversity body) => (contains r/text-section-2)
           (:values body) => (contains r/text-section-1)
@@ -230,7 +230,7 @@
           (:sections db-company) => new-set
           (:update db-company) => nil
           (:team db-company) => nil
-          (:finances db-company) => (contains r/finances-section-1)
+          (:finances db-company) => nil
           (:help db-company) => (contains r/text-section-1)
           (:diversity db-company) => (contains r/text-section-2)
           (:values db-company) => (contains r/text-section-1)))

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -57,13 +57,13 @@
 
     (let [add-section (fn [c section-name] (assoc c section-name (merge {:title (name section-name) :description "x"})))]
       (facts "it returns the sections in the company in the pre-defined order"
-        (:sections (c/create-company! conn (c/->company r/open r/coyote))) => {:progress [] :financial [] :company []}
+        (:sections (c/create-company! conn (c/->company r/open r/coyote))) => {:progress [] :company []}
         (c/delete-company conn r/slug)
         (:sections (c/create-company! conn (c/->company (add-section r/open :update) r/coyote))) =>
-        {:progress [:update] :financial [] :company []}
+        {:progress [:update] :company []}
         (c/delete-company conn r/slug)
         (:sections (c/create-company! conn (c/->company (add-section r/open :values) r/coyote))) =>
-        {:progress [] :financial [] :company [:values]}
+        {:progress [] :company [:values]}
         (c/delete-company conn r/slug)
         (:sections (c/create-company!
                     conn
@@ -71,4 +71,4 @@
                                      (add-section :mission) (add-section :press) (add-section :help)
                                      (add-section :challenges) (add-section :diversity) (add-section :update))
                                  r/coyote)))
-        => {:progress [:update :challenges :press] :financial [] :company [:mission :diversity :help]})))))
+        => {:progress [:update :challenges :press] :company [:mission :diversity :help]})))))

--- a/test/open_company/unit/resources/company/company_create.clj
+++ b/test/open_company/unit/resources/company/company_create.clj
@@ -71,4 +71,4 @@
                                      (add-section :mission) (add-section :press) (add-section :help)
                                      (add-section :challenges) (add-section :diversity) (add-section :update))
                                  r/coyote)))
-        => {:progress [:update :challenges :press] :company [:mission :diversity :help]})))))
+        => {:progress [:update :challenges :press :help] :company [:mission :diversity]})))))

--- a/test/open_company/unit/resources/company/company_manipulate.clj
+++ b/test/open_company/unit/resources/company/company_manipulate.clj
@@ -23,7 +23,7 @@
 
     (fact "with missing placeholder sections"
       (let [company (c/get-company conn r/slug)
-            missing-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+            missing-sections {:sections {:progress ["highlights" "help"] :company ["ownership"]}}
             fixed-company (c/add-placeholder-sections (merge company missing-sections))] ; this is what's tested
         (:highlights fixed-company) => (-> (common/section-by-name "highlights")
                                            (assoc :placeholder true)
@@ -37,7 +37,7 @@
 
     (future-fact "with partially specified placeholder sections"
       (let [company (c/get-company conn r/slug)
-            updated-sections {:sections {:progress ["highlights"] :company ["help"] :financial ["ownership"]}}
+            updated-sections {:sections {:progress ["highlights" "help"] :company ["ownership"]}}
             updated-content (-> updated-sections
                                 (assoc :highlights {:body "body a"})
                                 (assoc :help {:title "title b" :body "body b"})
@@ -67,7 +67,7 @@
       ;; remove the sections
       (let [company (c/get-company conn r/slug)
             updated-company (-> company 
-                                (assoc :sections {:sections {:progress [] :company [] :financial []}})
+                                (assoc :sections {:sections {:progress [] :company []}})
                                 (dissoc :update))]
         (c/update-company conn r/slug updated-company))
       ;; verify the sections are gone
@@ -76,7 +76,7 @@
       (:finances (c/get-company conn r/slug)) => nil
       ;; velify missing prior sections comes back
       (let [company (c/get-company conn r/slug)
-            missing-sections {:sections {:progress ["update"] :company ["values"] :financial []}}
+            missing-sections {:sections {:progress ["update"] :company ["values"]}}
             fixed-company (c/add-prior-sections conn (merge company missing-sections))] ; this is what's tested
         (:update fixed-company) => (contains r/text-section-1)
         (:values fixed-company) => (contains r/text-section-2)


### PR DESCRIPTION
https://trello.com/c/7kDEhTVe

This PR:

* removes the "financial" category
* removes the data privacy section
* moves sections into the 2 remaining categories
* updates tests to reflect the above changes
* updates README to reflect the above changes
* Moves the help and kudos sections
* Removes outro/intro from SUs

This has been deployed to staging already and the sample data there has been updated. To test:

Review the code.

Tests passing?

README REPL and cURL code works?

Look at the JSON company responses for a few companies on staging. No financial category? Dashboard and add topics still work OK? No data privacy section in add topics? No intro/outro in SU?

List SU's for Buffer with a GET (cURL). No intros? GET a specific SU with it's link. No intros/outros in either?

To deploy to prod:
* Deploy to prod
* Reimport sample data
* Ping Sean on Slack to manually touch up prod companies (OC, Prompt, etc.)