### PR TITLE
Include location in response to snapshot creation.

### DIFF
--- a/src/open_company/api/stakeholder_updates.clj
+++ b/src/open_company/api/stakeholder_updates.clj
@@ -26,9 +26,10 @@
     (common/missing-response)))
 
 (defn- stakeholder-update-location-response [update]
-  )
-  ; (common/location-response ["companies" (:symbol company)]
-  ;   (company-rep/render-company conn company) company-rep/media-type))
+  (let [company-slug (:company-slug update)
+        company-url (company-rep/url company-slug)]
+    (common/location-response ["companies" company-slug "updates" (:slug update)]
+      (su-rep/render-stakeholder-update company-url update true) su-rep/media-type)))
 
 ;; ----- Actions -----
 

--- a/src/open_company/resources/stakeholder_update.clj
+++ b/src/open_company/resources/stakeholder_update.clj
@@ -1,5 +1,6 @@
 (ns open-company.resources.stakeholder-update
-  (:require [schema.core :as schema]
+  (:require [clojure.string :as s]
+            [schema.core :as schema]
             [if-let.core :refer (if-let*)]
             [defun :refer (defun-)]
             [open-company.lib.slugify :as slug]
@@ -17,7 +18,8 @@
 (defn- slug-for
   "Create a slug for the stakeholder update from the slugified title and a short UUID."
   [title]
-  (str (slug/slugify title) "-" (subs (str (java.util.UUID/randomUUID)) 0 4)))
+  (let [non-blank-title (if (s/blank? title) "update" title)]
+    (str (slug/slugify non-blank-title) "-" (subs (str (java.util.UUID/randomUUID)) 0 4))))
 
 (defun- sections-for
   "Recursive function to get each specified section and add it to the stakeholder update."


### PR DESCRIPTION
https://trello.com/c/7XF15qY8

Add location header in response when SU is created via POST.

To test:

Before this (on mainline) run:

```
curl --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoic2xhY2s6VTA2U0JUWEpSIiwibmFtZSI6IlNlYW4gSm9obnNvbiIsInJlYWwtbmFtZSI6IlNlYW4gSm9obnNvbiIsImF2YXRhciI6Imh0dHBzOlwvXC9zZWN1cmUuZ3JhdmF0YXIuY29tXC9hdmF0YXJcL2Y1YjhmYzFhZmZhMjY2YzgwNzIwNjhmODExZjYzZTA0LmpwZz9zPTE5MiZkPWh0dHBzJTNBJTJGJTJGc2xhY2suZ2xvYmFsLnNzbC5mYXN0bHkubmV0JTJGN2ZhOSUyRmltZyUyRmF2YXRhcnMlMkZhdmFfMDAyMC0xOTIucG5nIiwiZW1haWwiOiJzZWFuQG9wZW5jb21wYW55LmNvbSIsIm93bmVyIjpmYWxzZSwiYWRtaW4iOnRydWUsIm9yZy1pZCI6InNsYWNrOlQwNlNCTUg2MCJ9.9Q8GNBojQ_xXT0lMtKve4fb5Pdh260oc2aUc-wP8dus" -X POST -i http://localhost:3000/companies/buffer/updates | grep Location
```

Notice the grep finds no `Location` header in the response.

Now, on this branch, try the same thing. This time grep finds a `Location` header in the response.

Notice the URL is: `/companies/buffer/updates/update-<uuid>`

That's because the snapshot has no title. You can give it a title at the REPL:

```clojure
(def conn2 [:host "127.0.0.1" :port 28015 :db "open_company_dev"])
(with-open [c (apply r/connect conn2)]
  (-> (r/table "companies")
      (r/get "buffer")
      (r/update {:stakeholder-update {:title "Foo Bar" :sections ["growth" "finances" "team" "product" "customer-service" "marketing" "help"]}})
      (r/run c)))
```

And run the cURL command again. Notice this time the URL is: `/companies/buffer/updates/foo-bar-<uuid>`

 Merge!