### PR TITLE
Return :archived topics in company responses. And archiving bug fix.

### DIFF
--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -96,13 +96,15 @@
 (defn- company-for-rendering
   "Get a representation of the company for the REST API"
   [conn company authorized]
+  (let [slug (:slug company)]
   (-> company
     (common/clean clean-properties)
-    (assoc :revisions (company/list-revisions conn (:slug company)))
-    (update :revisions #(map (fn [rev] (revision-link (:slug company) (:updated-at rev))) %))
+    (assoc :revisions (company/list-revisions conn slug))
+    (update :revisions #(map (fn [rev] (revision-link slug (:updated-at rev))) %))
     (company-links (if authorized :all-links [:self]))
     (stakeholder-update-links authorized)
-    (sections* conn authorized)))
+    (sections* conn authorized)
+    (assoc :archived (company/archived-sections conn slug)))))
 
 (defn render-company
   "Create a JSON representation of a company for the REST API"

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -165,7 +165,7 @@
 ;; ----- Utility functions -----
 
 (defn updated-at-order
-  "Return items in a sequence sorted by their :updated-at key."
+  "Return items in a sequence sorted by their :updated-at key. Newest first."
   [coll]
   (sort #(compare (:updated-at %2) (:updated-at %1)) coll))
 

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -1,5 +1,6 @@
 (ns open-company.resources.company
-  (:require [medley.core :as med]
+  (:require [if-let.core :refer (if-let*)]
+            [medley.core :as med]
             [schema.core :as schema]
             [open-company.resources.common :as common]))
 
@@ -20,6 +21,7 @@
   simply meta-data for the UI.
   "
   #{:core :prompt :standard-metrics :units :intervals})
+
 ;; ----- Utility functions -----
 
 (defn- clean
@@ -32,7 +34,7 @@
   [company]
   (assoc company :categories common/category-names))
 
-(defn- section-list
+(defn- section-set
   "Return the set of section names that are contained in the provided company."
   [company]
   (set (clojure.set/intersection common/section-names (set (keys company)))))
@@ -41,7 +43,7 @@
   "Add a :sections key to given company containing category->ordered-sections mapping
   Only add sections to the ordered-sections list that are used in the company map"
   [company]
-  (let [seclist (section-list company)]
+  (let [seclist (section-set company)]
     (->> (for [[cat sects] common/category-section-tree]
           [cat (vec (filter (set seclist) sects))])
       (into {})
@@ -51,7 +53,7 @@
   "Remove any sections from the company that are not in the :sections property"
   [company]
   (let [sections (set (map keyword (flatten (vals (:sections company)))))]
-    (apply dissoc company (clojure.set/difference (section-list company) sections))))
+    (apply dissoc company (clojure.set/difference (section-set company) sections))))
 
 ;; ----- Company Slug -----
 
@@ -92,16 +94,16 @@
 (defn- core-placeholder-sections
   "Return a map of section-name -> section containing just the core
    placeholder sections in sections.json"
-  [company-slug]
+  [slug]
   (reduce (fn [s sec]
             (assoc s
-                   (:section-name sec)
-                   (apply dissoc 
-                      (-> sec
-                        (assoc :company-slug company-slug)
-                        (assoc :placeholder true)
-                        (dissoc :name))
-                      metadata-properties)))
+              (:section-name sec)
+              (apply dissoc 
+                (-> sec
+                  (assoc :company-slug slug)
+                  (assoc :placeholder true)
+                  (dissoc :name))
+                metadata-properties)))
           {}
           (filter :core common/sections)))
 
@@ -140,6 +142,28 @@
         prior-section-names (map #(keyword (:section-name %)) prior-sections)]
     (merge company (zipmap prior-section-names (map #(dissoc % :section-name) prior-sections)))))
 
+(defn archived-sections
+  "Return just the archived sections for the specified company. Response is a sequence of maps with `:section-name`
+  and `:title` for each archived section."
+  [conn slug]
+  (if-let* [company (get-company conn slug)
+            ; just the sections currently in use in the company
+            current-sections (section-set company)
+            ; get all sections for the company
+            all-sections (common/read-resources conn common/section-table-name "company-slug" slug
+              [:section-name :title :updated-at])
+            ; diff the current and all sections to get missing (archived) sections
+            archived-sections (remove #(current-sections (keyword (:section-name %))) all-sections)
+            sorted-archived-sections (sort-by :updated-at archived-sections)
+            ; only get the latest revision of each archived section
+            latest-archived (zipmap (map :section-name sorted-archived-sections) sorted-archived-sections)]
+      ; for each archived section, remove the :update-at key, and swap :section-name key name for :section
+      (->> latest-archived
+        (vals)
+        (map #(dissoc % :updated-at))
+        (map #(clojure.set/rename-keys % {:section-name :section}))  
+        (vec))))
+        
 (defn- real-sections
   "Select all non-placeholder sections from a company map"
   [company]

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -354,7 +354,7 @@
           (:sections patch3-body) => newer-sections
           (:update patch3-body) => (contains new-content)
           ; verify update is in the DB AND contains the latest content
-          (:update db2-company) => (contains new-content)))))
+          (:update db2-company) => (contains new-content))))
 
     (facts "with section content"
 

--- a/test/open_company/integration/section/section_manipulation.clj
+++ b/test/open_company/integration/section/section_manipulation.clj
@@ -245,9 +245,9 @@
             (:values body) => (contains r/text-section-1))
           ;; verify removed section is archived
           (doseq [body [patch-body get-body]]
-            (:archived body) => [{:section "update" :title "Text Section 1"}
-                                  {:section "finances" :title "Finances Section 1"}
-                                  {:section "team" :title "Text Section 2"}])))
+            (:archived body) => [{:section "team" :title "Text Section 2"}
+                                 {:section "finances" :title "Finances Section 1"}
+                                 {:section "update" :title "Text Section 1"}])))
 
       (fact "a section can be removed from the company category"
         (let [new-order {:company ["diversity"]
@@ -295,9 +295,9 @@
             (:values body) => (contains r/text-section-1))
           ;; verify removed section is archived
           (doseq [body [patch-body get-body]]
-            (:archived body) => [{:section "finances" :title "Finances Section 1"}
+            (:archived body) => [{:section "diversity" :title "Text Section 2"}
                                  {:section "team" :title "Text Section 2"}
-                                 {:section "diversity" :title "Text Section 2"}]))))
+                                 {:section "finances" :title "Finances Section 1"}]))))
   
   (facts "about adding sections"
 
@@ -327,8 +327,9 @@
           db-highlights => (contains placeholder)))
 
       (fact "that used to exist"
-        ; First, update the content using another user to create a newer revision
-        (let [new-content {:title "Update" :headline "Headline #2" :body "Update #2."}
+        (let [_delay (Thread/sleep 1000) ; wait long enough for timestamps of the new revision to differ definitively
+              new-content {:title "Update" :headline "Headline #2" :body "Update #2."}
+              ; Update the content using another user to create a newer revision
               patch1-response (mock/api-request :patch (section-rep/url r/slug "update") {:auth mock/jwtoken-camus 
                                                                                           :body new-content})
               ; Then remove the content
@@ -353,7 +354,7 @@
           (:sections patch3-body) => newer-sections
           (:update patch3-body) => (contains new-content)
           ; verify update is in the DB AND contains the latest content
-          (:update db2-company) => (contains new-content))))
+          (:update db2-company) => (contains new-content)))))
 
     (facts "with section content"
 

--- a/test/open_company/unit/resources/common.clj
+++ b/test/open_company/unit/resources/common.clj
@@ -4,6 +4,6 @@
 
 (facts "about with-timeout macro"
   (let [s "result"] 
-    (co/with-timeout 50 s) => s
-    (co/with-timeout 50 (do (Thread/sleep 40) s) => s)
-    (co/with-timeout 50 (do (Thread/sleep 60) s)) => (throws Exception)))
+    (co/with-timeout 30 s) => s
+    (co/with-timeout 30 (do (Thread/sleep 20) s) => s)
+    (co/with-timeout 30 (do (Thread/sleep 90) s)) => (throws Exception)))


### PR DESCRIPTION
https://trello.com/c/2rlA4fLv

This test fixes a bug where re-adding an archived section causes the oldest section to be added back. It also adds an `archived` key to company containing all the company's archived sections (names and titles).

To test the bug fix:

* Start w/ a cleanly imported Buffer **ON MAINLINE**
* Archive "Team and Hiring"
* Add "team" topic back in, look at the content, notice it's now showing the oldest content, (July 13, 2015), not the latest content, this is bad.
* Now switch to this branch and start again w/ a cleanly imported Buffer
* Archive "Team and Hiring"
* Add "team" topic back in, look at the content, notice it's now showing the newest content, (November 20, 2015), this is good.

To test the `archived` key:

* Start w/ a cleanly imported Buffer on this branch
* Look at the response, is there an `archived` key? Is it empty? Super.
* Archive a topic, such as "finances". Look at the response to the PATCH that archived it, is finances in the `archived` key? Nice.
* Refresh the page, finance still there in `archived`? No we're cooking.
* Now a tricky test. Retitle something, such as change the title of "Values" to "Valuables". Post the change. Then archive the values section. Check the response to the PATCH and to a new GET. Is values in there, with a title of "Valuables"? Looks like we did it!

Then:

* Review the code and tests, tests cover the code changes, requirements, and bug?
* Tests passing?
* Merge
* Deploy
* Do the limbo