### PR TITLE
Snapshot POST bug on staging/prod

### DIFF
--- a/docs/stakeholder-updates.md
+++ b/docs/stakeholder-updates.md
@@ -33,7 +33,7 @@ dashboard (shouldn't actually happen) should be skipped. Any section that's stil
 
 ## Stakeholder Content Editing / Ordering
 
-The intro for the "live" and next pending shared stakeholder update can be edited by `PATCH`ing the company.
+The title for the "live" next pending shared stakeholder update can be edited by `PATCH`ing the company.
 
 Sections in the next pending stakeholder update can be added, removed, reordered by `PATCH`ing the company. Only
 sections active in the dashboard can be included. Including other sections returns a `422` error.
@@ -42,8 +42,8 @@ sections active in the dashboard can be included. Including other sections retur
 ## Stakeholder Update Creating
 
 A blank POST to `/companies/{slug}/updates` creates a new stakeholder update from the current "live" pending
-stakeholeder update and resets the intro to the blank state (no author, no timestamp, blank body). The authorized
-user doing the POST is captured in the created stakeholder update as the author.
+stakeholeder update and resets the title to blank. The authorized user doing the POST is captured in the created
+stakeholder update as the author.
 
 
 ## List of Prior Stakeholder Updates

--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
     [http-kit "2.2.0-alpha1"] ; Web server http://http-kit.org/
     [compojure "1.5.0"] ; Web routing https://github.com/weavejester/compojure
     [liberator "0.14.1"] ; WebMachine (REST API server) port to Clojure https://github.com/clojure-liberator/liberator
-    [com.apa512/rethinkdb "0.15.20"] ; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
+    [com.apa512/rethinkdb "0.15.23"] ; RethinkDB client for Clojure https://github.com/apa512/clj-rethinkdb
     [prismatic/schema "1.1.1"] ; Data validation https://github.com/Prismatic/schema
     [environ "1.0.3"] ; Environment settings from different sources https://github.com/weavejester/environ
     [com.taoensso/timbre "4.4.0-alpha1"] ; Logging https://github.com/ptaoussanis/timbre

--- a/project.clj
+++ b/project.clj
@@ -71,6 +71,9 @@
         :hot-reload "true" ; reload code when changed on the file system
         :open-company-auth-passphrase "this_is_a_dev_secret" ; JWT secret
       }
+      :dependencies [
+        [philoskim/debux "0.2.1"] ; `dbg` macro around -> or lets https://github.com/philoskim/debux
+      ]
       :plugins [
         [lein-bikeshed "0.3.0"] ; Check for code smells https://github.com/dakrone/lein-bikeshed
         [lein-checkall "0.1.1"] ; Runs bikeshed, kibit and eastwood https://github.com/itang/lein-checkall

--- a/src/open_company/api/stakeholder_updates.clj
+++ b/src/open_company/api/stakeholder_updates.clj
@@ -45,13 +45,11 @@
     false))
 
 (defn- create-stakeholder-update [conn {:keys [company user] :as ctx}]
-  (assoc ctx :stakeholder-update (su-res/create-stakeholder-update!
-    conn
-    (su-res/->stakeholder-update
-      conn
+  (su-res/create-stakeholder-update! conn
+    (su-res/->stakeholder-update conn
       company
       (:stakeholder-update company)
-      user))))
+      user)))
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
 
@@ -103,7 +101,7 @@
 
   ;; Create a new stakeholder update
   :post-to-missing? false ; 404 if company doesn't exist
-  :post! (fn [ctx] (create-stakeholder-update conn ctx))
+  :post! (fn [ctx] {:stakeholder-update (create-stakeholder-update conn ctx)})
 
   ;; Handlers
   :handle-not-acceptable (common/only-accept 406 su-rep/collection-media-type)

--- a/src/open_company/resources/stakeholder_update.clj
+++ b/src/open_company/resources/stakeholder_update.clj
@@ -42,11 +42,9 @@
   
   ([conn company su-props user] (->stakeholder-update conn company su-props (common/current-timestamp) user))
   
-  ([conn company {:keys [title intro outro sections] :as su-props} timestamp user]
+  ([conn company {:keys [title sections] :as su-props} timestamp user]
   {:pre [(map? conn)
          (string? title)
-         (or (map? intro) (nil? intro))
-         (or (map? outro) (nil? outro))
          (sequential? sections)
          (map? user)]
    :post [(map? %)]} ; title and sections required


### PR DESCRIPTION
https://trello.com/c/Tp81KgiO

Fixes bug: can't directly assoc on the liberator request context when using nginx-clojure. Need to update it indirectly by returning a map that liberator merges in itself (this is the right way to do it anyway). Also a bit more cleanup removing intro/outro.

To test:

* Run API on this branch
* Create a snapshot with the web UI
* Share the URL. Does the POST work or does it 500? Works? About damn time.
* Merge
* Deploy
* Sing the hits of Neil Diamond