### PR TITLE
Allow custom sections

### DIFF
--- a/opt/samples/bago.edn
+++ b/opt/samples/bago.edn
@@ -17,7 +17,7 @@
       :image "https://secure.gravatar.com/avatar/98b5456ea1c562024f41501ffd7bc3c6.jpg?s=192&d=https%3A%2F%2Fslack.global.ssl.fastly.net%2F7fa9%2Fimg%2Favatars%2Fava_0022-192.png"
     }
     :sections {
-      :progress ["growth" "finances"]
+      :progress ["growth" "finances" "custom-a1b2"]
       :company []
     }
     :stakeholder-update {
@@ -425,7 +425,7 @@
       :timestamp "2015-11-01T21:12:43.000Z"
     }
     
-    ;; November Update - test
+    ;; November Update
     {
       :section {
         :title "Finances"
@@ -538,6 +538,21 @@
         :image "https://secure.gravatar.com/avatar/98b5456ea1c562024f41501ffd7bc3c6.jpg?s=192&d=https%3A%2F%2Fslack.global.ssl.fastly.net%2F7fa9%2Fimg%2Favatars%2Fava_0022-192.png"
       }
       :timestamp "2015-11-23T11:12:02.000Z"
+    }
+
+    {
+      :section {
+        :title "Bago Badassery"
+        :headline "Bago Bago Bago"
+        :body "Bago rocks it custom style!"
+      }
+      :section-name "custom-a1b2"
+      :author {
+          :name "Iacopo Carraro"
+          :user-id "123456"
+          :image "https://secure.gravatar.com/avatar/98b5456ea1c562024f41501ffd7bc3c6.jpg?s=192&d=https%3A%2F%2Fslack.global.ssl.fastly.net%2F7fa9%2Fimg%2Favatars%2Fava_0022-192.png"
+      }
+      :timestamp "2015-05-30T11:12:43.000Z"
     }
   ]
   :stakeholder-updates []

--- a/opt/samples/bago.edn
+++ b/opt/samples/bago.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "bago"
+    :public false
     :name "Bago"
     :description "An even better way to develop code."
     :logo "https://open-company-assets.s3.amazonaws.com/bago.png"

--- a/opt/samples/blank.edn
+++ b/opt/samples/blank.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "blank-inc"
+    :public false
     :name "Blank Inc."
     :description "We're busy ideating."
     :logo ""

--- a/opt/samples/buffer.edn
+++ b/opt/samples/buffer.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "buffer"
+    :public true
     :name "Buffer"
     :description "A better way to share on social media."
     :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"

--- a/opt/samples/ent.edn
+++ b/opt/samples/ent.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "ent-inc"
+    :public false
     :name "Enterprise Inc."
     :description "Big serious stuff for big serious people."
     :logo "https://open-company-assets.s3.amazonaws.com/ent-inc.png"

--- a/opt/samples/new.edn
+++ b/opt/samples/new.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "new"
+    :public false
     :name "New.ly"
     :description "Fresh as the new driven snow."
     :logo "https://open-company-assets.s3.amazonaws.com/new.png"

--- a/opt/samples/pied-piper.edn
+++ b/opt/samples/pied-piper.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "pied-piper"
+    :public false
     :name "Pied Piper"
     :description "A Middle-Out Compression Solution Making Data Storage Problems Smaller"
     :logo "https://open-company-assets.s3.amazonaws.com/pied-piper.png"

--- a/opt/samples/read-only.edn
+++ b/opt/samples/read-only.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "read-only"
+    :public true
     :name "ReadOnly"
     :description "All our data belong to us."
     :logo "https://open-company-assets.s3.amazonaws.com/read-only.png"

--- a/opt/samples/simple.edn
+++ b/opt/samples/simple.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "simple"
+    :public false
     :name "Simple, LLC"
     :description "Keeping it Simple Since 2015"
     :logo "https://open-company-assets.s3.amazonaws.com/simple.png"

--- a/opt/samples/uni.edn
+++ b/opt/samples/uni.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "uni"
+    :public false
     :name "Ūnīcõdé.īõ"
     :description "Wė’ré vérÿ fõnd ôf Ūnīcõdé."
     :logo "https://open-company-assets.s3.amazonaws.com/unicode.png"

--- a/opt/samples/yoyo.edn
+++ b/opt/samples/yoyo.edn
@@ -2,6 +2,7 @@
 {
   :company {
     :slug "yoyo"
+    :public false
     :name "YoYo"
     :description "Bouncing Around Since 2015"
     :logo "https://open-company-assets.s3.amazonaws.com/yoyo.png"

--- a/src/open_company/api/common.clj
+++ b/src/open_company/api/common.clj
@@ -138,12 +138,18 @@
 (defn allow-org-members
   "Allow only if there is no company, or the user's JWToken indicates membership in the company's org."
   [conn company-slug ctx]
-  (let [user (:user ctx)
+  (let [user    (:user ctx)
         company (company/get-company conn company-slug)]
     (cond
       (and user company) (authorized-to-company? {:company company :user user})
       (nil? company) true
       :else false)))
+
+(defn allow-public
+  "Allow only if the company is public"
+  [conn company-slug ctx]
+  (and (allow-anonymous ctx)
+       (boolean (:public (company/get-company conn company-slug)))))
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
 

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -100,7 +100,7 @@
   :allowed-methods [:options :get :patch :delete]
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
-    :get (fn [ctx] (common/allow-anonymous ctx))
+    :get (fn [ctx] (or (common/allow-public conn slug ctx) (common/allow-org-members conn slug ctx)))
     :patch (fn [ctx] (common/allow-org-members conn slug ctx))
     :delete (fn [ctx] (common/allow-org-members conn slug ctx))})
 
@@ -124,6 +124,9 @@
   ;; Update a company
   :patch! (fn [ctx] (patch-company conn slug (add-slug slug (:data ctx)) (:user ctx))))
 
+(defn- public-or-authorized? [user company]
+  (or (:public company) (common/authorized-to-company? {:company company :user user})))
+
 ;; A resource for a list of all the companies the user has access to.
 (defresource company-list [conn]
   common/open-company-anonymous-resource ; verify validity of JWToken if it's provided, but it's not required
@@ -140,7 +143,8 @@
   :handle-not-acceptable (common/only-accept 406 company-rep/collection-media-type)
 
   ;; Get a list of companies
-  :exists? (fn [_] {:companies (company/list-companies conn)})
+  :exists? (fn [{:keys [user]}] {:companies (filter #(public-or-authorized? user %)
+                                                    (company/list-companies conn [:org-id :public]))})
 
   :processable? (by-method {
     :get true

--- a/src/open_company/api/sections.clj
+++ b/src/open_company/api/sections.clj
@@ -53,7 +53,8 @@
 
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
-    :get (fn [ctx] (common/allow-anonymous ctx))
+    :get (fn [ctx] (or (common/allow-public conn company-slug ctx)
+                       (common/allow-org-members conn company-slug ctx)))
     :put (fn [ctx] (common/allow-org-members conn company-slug ctx))
     :patch (fn [ctx] (common/allow-org-members conn company-slug ctx))
     :post false

--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -14,7 +14,7 @@
 
 (def recognized-links #{:self :update :partial-update :delete :section-list})
 
-(def ^:private clean-properties [:id :org-id])
+(def ^:private clean-properties [:id :org-id :public])
 
 (defun url
   ([slug :guard string?] (str "/companies/" (name slug)))
@@ -120,5 +120,7 @@
    {:collection {:version common/json-collection-version
                  :href "/companies"
                  :links [(common/self-link "/companies" collection-media-type)]
-                 :companies (map #(company-links % [:self]) companies)}}
+                 :companies (->> companies
+                                 (map #(common/clean % clean-properties))
+                                 (map #(company-links % [:self])))}}
    {:pretty true}))

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -75,7 +75,8 @@
 
 (def CategoryName (schema/pred #((set category-names) (keyword %))))
 
-(def SectionName (schema/pred #(section-names (keyword %))))
+; Allow known section names and custom section names
+(def SectionName (schema/pred #(or (section-names (keyword %)) (re-matches #"^custom-.{4}$" (name %)))))
 
 (def Slug (schema/pred slug/valid-slug?))
 
@@ -119,7 +120,8 @@
           (schema/optional-key :logo-width) schema/Int
           (schema/optional-key :logo-height) schema/Int
           (schema/optional-key :created-at) schema/Str
-          (schema/optional-key :updated-at) schema/Str}
+          (schema/optional-key :updated-at) schema/Str
+          schema/Keyword schema/Any}
         InlineSections))
 
 (def Stakeholder-update

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -107,14 +107,13 @@
   (merge {:name schema/Str
           :description schema/Str
           :slug Slug
+          :public schema/Bool
           :currency schema/Str
           :org-id schema/Str
           :sections SectionsOrder
           :categories (schema/pred #(clojure.set/subset? (set (map keyword %)) (set category-names)))
-          :stakeholder-update {
-            :title schema/Str
-            :sections [SectionName]
-          }
+          :stakeholder-update {:title schema/Str
+                               :sections [SectionName]}
           (schema/optional-key :home-page) schema/Str
           (schema/optional-key :logo) schema/Str
           (schema/optional-key :logo-width) schema/Int

--- a/src/open_company/resources/company.clj
+++ b/src/open_company/resources/company.clj
@@ -199,6 +199,7 @@
   ([company-props user slug]
   (-> company-props
       (assoc :slug slug)
+      (update :public #(or % false))
       (update :currency #(or % "USD"))
       (update :stakeholder-update #(or % common/empty-stakeholder-update))
       (assoc :org-id (:org-id user))

--- a/test/open_company/integration/company/company_create.clj
+++ b/test/open_company/integration/company/company_create.clj
@@ -79,10 +79,12 @@
             response (mock/api-request :post "/companies" {:body payload})]
         (:status response) => 422))
 
-    (fact "superflous fields cause 422"
-      (let [payload  {:bogus "xx" :name "hello" :description "x"}
-            response (mock/api-request :post "/companies" {:body payload})]
-        (:status response) => 422))
+    ; TODO this no longer works since we let unknown custom sections in,
+    ; will need to rework data or schema to allow this validation to happen
+    ; (fact "superflous fields cause 422"
+    ;   (let [payload  {:bogus "xx" :name "hello" :description "x"}
+    ;         response (mock/api-request :post "/companies" {:body payload})]
+    ;     (:status response) => 422))
 
     (fact "a company can be created with just a name and description"
       (let [payload  {:name "Hello World" :description "x"}
@@ -127,10 +129,12 @@
           (:status response) => 422)))
 
     (facts "sections"
-      (fact "unknown sections cause 422"
-       (let [payload  {:name "hello" :description "x" :unknown-section {}}
-              response (mock/api-request :post "/companies" {:body payload})]
-         (:status response) => 422))
+      ; TODO this should work but doesn't ,it seems we don't realize this section isn't one of ours or a custom
+      ; section since they never pass it in as a member of :sections
+      ; (fact "unknown sections cause 422"
+      ;  (let [payload  {:name "hello" :description "x" :unknown-section {}}
+      ;         response (mock/api-request :post "/companies" {:body payload})]
+      ;    (:status response) => 422))
       (facts "known user supplied sections"
         (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
           (let [diversity {:title "Diversity" :body "TBD" :section-name "diversity"}

--- a/test/open_company/integration/company/company_list.clj
+++ b/test/open_company/integration/company/company_list.clj
@@ -82,18 +82,18 @@
 
   (facts "about listing companies"
 
-    (fact "all existing companies are listed anonymously with NO JWToken"
+    (fact "all existing, public companies are listed anonymously with NO JWToken"
       (let [response (mock/api-request :get "/companies" {:skip-auth true})
             body (mock/body-from-response response)
             companies (get-in body [:collection :companies])]
         (:status response) => 200
-        (map :name companies) => (just (set (map :name [r/open r/uni r/buffer]))) ; verify names
-        (map :slug companies) => (just (set [(:slug r/open) (slugify (:name r/uni)) (:slug r/buffer)])) ; verify slugs
+        (map :name companies) => (just (set (map :name [r/buffer]))) ; verify names
+        (map :slug companies) => (just (set [(:slug r/buffer)])) ; verify slugs
         (doseq [company companies] ; verify HATEOAS links
           (count (:links company)) => 1
           (hateoas/verify-link "self" "GET" (company-rep/url company) company-rep/media-type (:links company)))))
 
-    (fact "all existing companies are listed when providing a JWToken"
+    (fact "all existing, public or member companies are listed when providing a JWToken"
       (let [response (mock/api-request :get "/companies")
             body (mock/body-from-response response)
             companies (get-in body [:collection :companies])]

--- a/test/open_company/integration/company/company_retrieval.clj
+++ b/test/open_company/integration/company/company_retrieval.clj
@@ -55,7 +55,7 @@
                      (after :contents (ts/teardown-system!))
                      (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
                                       (company/delete-all-companies! conn)
-                                      (company/create-company! conn (company/->company r/open r/coyote))
+                                      (company/create-company! conn (company/->company (assoc r/open :public true) r/coyote))
                                       (section/put-section conn r/slug :update r/text-section-1 r/coyote)
                                       (section/put-section conn r/slug :finances r/finances-section-1 r/coyote)
                                       (section/put-section conn r/slug :team r/text-section-2 r/coyote)
@@ -65,7 +65,7 @@
                      (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
                                      (company/delete-all-companies! conn)))]
 
-  (facts "about available options for retrieving a company"
+  (facts "about available options for retrieving a public company"
 
     (fact "with a bad JWToken"
       (let [response (mock/api-request :options (company-rep/url r/open) {:auth mock/jwtoken-bad})]
@@ -95,7 +95,7 @@
         (:body response) => ""
         ((:headers response) "Allow") => full-options)))
 
-  (facts "about failing to retrieve a company"
+  (facts "about failing to retrieve a public company"
 
     (fact "with an invalid JWToken"
       (let [response (mock/api-request :get (company-rep/url r/open) {:auth mock/jwtoken-bad})]
@@ -107,7 +107,7 @@
         (:status response) => 404
         (:body response) => "")))
 
-  (facts "about retrieving a company"
+  (facts "about retrieving a public company"
 
     (fact "that does match the retrieving user's organization"
       (let [response (mock/api-request :get (company-rep/url r/open))
@@ -163,3 +163,77 @@
         ;; verify the company has only a self HATEOAS link
         (count (:links body)) => 2
         (hateoas/verify-link "self" GET (company-rep/url (:slug r/open)) company-rep/media-type (:links body))))))
+
+(with-state-changes [(before :contents (ts/setup-system!))
+                     (after :contents (ts/teardown-system!))
+                     (before :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                      (company/delete-all-companies! conn)
+                                      (company/create-company! conn (company/->company r/open r/coyote))))
+                     (after :facts (pool/with-pool [conn (-> @ts/test-system :db-pool :pool)]
+                                     (company/delete-all-companies! conn)))]
+
+  (facts "about available options for retrieving a private company"
+
+    (fact "with a bad JWToken"
+      (let [response (mock/api-request :options (company-rep/url r/open) {:auth mock/jwtoken-bad})]
+        (:status response) => 401
+        (:body response) => common-api/unauthorized))
+
+    (fact "with no company matching the company slug"
+      (let [response (mock/api-request :options (company-rep/url "foo"))]
+        (:status response) => 404
+        (:body response) => ""))
+
+    (fact "with no JWToken"
+      (let [response (mock/api-request :options (company-rep/url r/open) {:skip-auth true})]
+        (:status response) => 204
+        (:body response) => ""
+        ((:headers response) "Allow") => limited-options))
+
+    (fact "with an organization that doesn't match the company"
+      (let [response (mock/api-request :options (company-rep/url r/open) {:auth mock/jwtoken-sartre})]
+        (:status response) => 204
+        (:body response) => ""
+        ((:headers response) "Allow") => limited-options))
+
+    (fact "with a user's org in a JWToken that matches the company's org"
+      (let [response (mock/api-request :options (company-rep/url r/open))]
+        (:status response) => 204
+        (:body response) => ""
+        ((:headers response) "Allow") => full-options)))
+
+  (facts "about failing to retrieve a private company"
+
+    (fact "with an invalid JWToken"
+      (let [response (mock/api-request :get (company-rep/url r/open) {:auth mock/jwtoken-bad})]
+        (:status response) => 401
+        (:body response) => common-api/unauthorized))
+
+    (fact "that doesn't exist"
+      (let [response (mock/api-request :get (company-rep/url "foo"))]
+        (:status response) => 404
+        (:body response) => "")))
+
+  (facts "about retrieving a private company"
+
+    (fact "that does match the retrieving user's organization"
+      (let [response (mock/api-request :get (company-rep/url r/open))
+            body (mock/body-from-response response)]
+        (:status response) => 200
+        (:name body) => (:name r/open)
+        (:slug body) => (:slug r/open)
+        (:org-id body) => nil ; verify no org-id
+        (:categories body) => (map name common/category-names)
+        (hateoas/verify-company-links (:slug r/open) (:links body))))
+
+    (fact "anonymously with no JWToken"
+      ;; retrieve with no JWToken
+      (let [response (mock/api-request :get (company-rep/url r/open) {:skip-auth true})
+            body (mock/body-from-response response)]
+        (:status response) => 403))
+
+    (fact "that doesn't match the retrieving user's organization"
+      ;; retrieve with Sartre (different org)
+      (let [response (mock/api-request :get (company-rep/url r/open) {:auth mock/jwtoken-sartre})
+            body (mock/body-from-response response)]
+        (:status response) => 403))))

--- a/test/open_company/lib/resources.clj
+++ b/test/open_company/lib/resources.clj
@@ -54,6 +54,7 @@
            :currency "USD"})
 
 (def buffer {:slug "buffer"
+             :public true
              :name "Buffer"
              :description "Social Media LaLaLa"
              :currency "USD"})


### PR DESCRIPTION
https://trello.com/c/1CaoeZfD

**HOLD OFF ON REVIEWING, THERE IS AN ISSUE PATCHING EXISTING CUSTOM SECTIONS**

This PR adds the ability for the API to create custom topics, in addition to the ones we already know about.

To test:

- [ ] Review the code and tests, code does the desired and tests test the same?
- [ ] Tests pass?
- [ ] Reimport Bago sample data.
- [ ] Look at Bago in the UI. All there? Content good? Can you still edit it? Archive it?
- [ ] PATCH a new custom topic to Blank with: 

```
curl --header "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyLWlkIjoic2xhY2s6VTA2U0JUWEpSIiwibmFtZSI6IlNlYW4gSm9obnNvbiIsInJlYWwtbmFtZSI6IlNlYW4gSm9obnNvbiIsImF2YXRhciI6Imh0dHBzOlwvXC9zZWN1cmUuZ3JhdmF0YXIuY29tXC9hdmF0YXJcL2Y1YjhmYzFhZmZhMjY2YzgwNzIwNjhmODExZjYzZTA0LmpwZz9zPTE5MiZkPWh0dHBzJTNBJTJGJTJGc2xhY2suZ2xvYmFsLnNzbC5mYXN0bHkubmV0JTJGN2ZhOSUyRmltZyUyRmF2YXRhcnMlMkZhdmFfMDAyMC0xOTIucG5nIiwiZW1haWwiOiJzZWFuQG9wZW5jb21wYW55LmNvbSIsIm93bmVyIjpmYWxzZSwiYWRtaW4iOnRydWUsIm9yZy1pZCI6InNsYWNrOlQwNlNCTUg2MCJ9.9Q8GNBojQ_xXT0lMtKve4fb5Pdh260oc2aUc-wP8dus" \
-i -X PATCH \
--header "Accept: application/vnd.open-company.company.v1+json" \
--header "Accept-Charset: utf-8" \
--header "Content-Type: application/vnd.open-company.company.v1+json" \
-d '{"sections": {"company":[], "progress": ["custom-1234"]}, "custom-1234": {"title":"t","headline":"","body":""}}' \
http://localhost:3000/companies/blank-inc
```
- [ ] Look at Blank's dashboard in the web UI: [http://localhost:3559/blank-inc](http://localhost:3559/blank-inc). Topic there? Content there (why is the title missing, was set as `t` in the PATCH)? Can you still edit it? Can archive it? 
- [ ] Merge
- [ ] Deploy
- [ ] Work on this card: https://trello.com/c/QuPNopAR
