### PR TITLE
Send logo as script param if present

### DIFF
--- a/src/open_company/lib/bot.clj
+++ b/src/open_company/lib/bot.clj
@@ -61,9 +61,9 @@
                     :stakeholder-update {:type :all-members})}))
 
 (defn send-trigger! [trigger]
-  (timbre/info "[bot] request to send " trigger " to " c/aws-sqs-queue)
+  (timbre/info "Request to send msg to " c/aws-sqs-queue "\n" trigger)
   (s/validate BotTrigger trigger)
-  (timbre/info "[bot] sending")
+  (timbre/info "Sending")
   (sqs/send-message
    {:access-key c/aws-access-key-id
     :secret-key c/aws-secret-access-key}

--- a/src/open_company/lib/bot.clj
+++ b/src/open_company/lib/bot.clj
@@ -23,7 +23,7 @@
 (defmulti adapt (fn [type _] type))
 
 (defmethod adapt :company [_ m]
-  (select-keys m [:name :slug :description :currency]))
+  (select-keys m [:name :logo :slug :description :currency]))
 
 (defmethod adapt :user [_ m]
   {:name (first (string/split (:real-name m) #"\ "))})


### PR DESCRIPTION
[trello card](https://trello.com/c/QTeRaScu/495-update-onboarding-script-to-update-logo-rather-than-name)

This is not actually required in 99% of the cases (companies usually don't have a logo when they onboard) but since the bot now does things with the logo it seems relevant enough to be included in the message.

No real test steps as well