### PR TITLE
Companies w/ no logo are not in the company list

### DIFF
--- a/opt/samples/buffer.edn
+++ b/opt/samples/buffer.edn
@@ -1732,8 +1732,8 @@
         :headline "We're building a more inclusive Buffer!"
         :snippet "<p>Here's a transparent look at the overall demographic diversity of our team.</p>"
         :image-url "http://take.ms/cTKFm"
-        :image-height 448
-        :image-width 555
+        :image-height 564
+        :image-width 699
         :body "        
         <img src=\"http://take.ms/3mBTC\">
         <img src=\"http://take.ms/3zi2y\">"
@@ -2134,8 +2134,8 @@
         More than 500,000 Pablo images have been created so far, and we're excited to keep going with our quick
         images tool.</p>"
         :image-url "https://open.buffer.com/wp-content/uploads/2015/11/Pablo-2-launch-social-media-images-800x643.png"
-        :image-height 446
-        :image-width 555
+        :image-height 643
+        :image-width 800
         :body "
         <p>We also made several improvements to Buffer for Business, including the move from 7 day to 30 day trials,
         a new groups UI, the ability to search profiles and improved reliability/speed of analytics.</p>

--- a/project.clj
+++ b/project.clj
@@ -28,7 +28,7 @@
     [prismatic/schema "1.1.2"] ; Data validation https://github.com/Prismatic/schema
     [environ "1.0.3"] ; Environment settings from different sources https://github.com/weavejester/environ
     [cheshire "5.6.3"] ; JSON encoding / decoding https://github.com/dakrone/cheshire
-    [com.taoensso/timbre "4.6.0"] ; Logging https://github.com/ptaoussanis/timbre
+    [com.taoensso/timbre "4.7.0"] ; Logging https://github.com/ptaoussanis/timbre
     [raven-clj "1.4.2"] ; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [clj-http "3.1.0"] ; HTTP client https://github.com/dakrone/clj-http
     [clj-time "0.12.0"] ; Date and time lib https://github.com/clj-time/clj-time
@@ -36,7 +36,7 @@
     [clj-jwt "0.1.1"] ; Library for JSON Web Token (JWT) https://github.com/liquidz/clj-jwt
     [medley "0.8.2"] ; Utility functions https://github.com/weavejester/medley
     [com.stuartsierra/component "0.3.1"] ; Component Lifecycle
-    [amazonica "0.3.66"] ; A comprehensive Clojure client for the entire Amazon AWS api https://github.com/mcohen01/amazonica
+    [amazonica "0.3.67"] ; A comprehensive Clojure client for the entire Amazon AWS api https://github.com/mcohen01/amazonica
   ]
 
   ;; All profile plugins

--- a/src/open_company/api/companies.clj
+++ b/src/open_company/api/companies.clj
@@ -67,6 +67,18 @@
     ;; update the company
     {:updated-company (company/put-company conn slug with-placeholders user)}))
 
+(defn- public-or-authorized? [user company]
+  (or (:public company) (common/authorized-to-company? {:company company :user user})))
+
+(defn- accessible-company-list
+  "Return a list of all companies this user has access to."
+  [conn user]
+  (let [logo-companies (company/list-companies conn [:org-id :public :logo]) ; every company w/ a logo
+        all-companies (company/list-companies conn [:org-id :public]) ; every company w/ or w/o a logo
+        logo-index (zipmap (map :slug logo-companies) (map :logo logo-companies))
+        companies (map #(assoc % :logo (logo-index (:slug %))) all-companies)] ; every company w/ a logo if they have it
+    (sort-by :name (filter #(public-or-authorized? user %) companies)))) ; public or authorized to this user
+
 ;; ----- Validations -----
 
 (defn processable-patch-req? [conn slug ctx]
@@ -125,9 +137,6 @@
   ;; Update a company
   :patch! (fn [ctx] (patch-company conn slug (add-slug slug (:data ctx)) (:user ctx))))
 
-(defn- public-or-authorized? [user company]
-  (or (:public company) (common/authorized-to-company? {:company company :user user})))
-
 ;; A resource for a list of all the companies the user has access to.
 (defresource company-list [conn]
   common/open-company-anonymous-resource ; verify validity of JWToken if it's provided, but it's not required
@@ -144,8 +153,7 @@
   :handle-not-acceptable (common/only-accept 406 company-rep/collection-media-type)
 
   ;; Get a list of companies
-  :exists? (fn [{:keys [user]}] {:companies (filter #(public-or-authorized? user %)
-                                                    (company/list-companies conn [:org-id :public :logo]))})
+  :exists? (fn [{:keys [user]}] {:companies (accessible-company-list conn user)})
 
   :processable? (by-method {
     :get true

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -1,4 +1,5 @@
 {
+  "sections": ["update", "mission", "values", "highlights", "growth", "challenges", "takeaways", "team", "diversity", "product", "customer-service", "sales", "marketing", "business-development", "competition", "press", "help", "kudos", "finances", "fundraising", "ownership", "compensation"],
   "categories": [
     {
       "name": "company",

--- a/test/open_company/integration/company/company_list.clj
+++ b/test/open_company/integration/company/company_list.clj
@@ -89,6 +89,7 @@
         (:status response) => 200
         (map :name companies) => (just (set (map :name [r/buffer]))) ; verify names
         (map :slug companies) => (just (set [(:slug r/buffer)])) ; verify slugs
+        (map :logo companies) => (just (set [(:logo r/buffer)])) ; verify logos
         (doseq [company companies] ; verify HATEOAS links
           (count (:links company)) => 1
           (hateoas/verify-link "self" "GET" (company-rep/url company) company-rep/media-type (:links company)))))
@@ -100,6 +101,7 @@
         (:status response) => 200
         (map :name companies) => (just (set (map :name [r/open r/uni r/buffer]))) ; verify names
         (map :slug companies) => (just (set [(:slug r/open) (slugify (:name r/uni)) (:slug r/buffer)])) ; verify slugs
+        (map :logo companies) => (just (set [(:logo r/open) (:logo r/uni) (:logo r/buffer)])) ; verify logos
         (doseq [company companies] ; verify HATEOAS links
           (count (:links company)) => 1
           (hateoas/verify-link "self" "GET" (company-rep/url company) company-rep/media-type (:links company)))))

--- a/test/open_company/lib/resources.clj
+++ b/test/open_company/lib/resources.clj
@@ -64,12 +64,11 @@
              :name "Buffer"
              :description "Social Media LaLaLa"
              :currency "USD"
-             :logo ""})
+             :logo "https://open-company-assets.s3.amazonaws.com/buffer.png"})
 
 (def uni {:name "$€¥£ &‼⁇ ∆∰≈ ☃♔☂Ǽ ḈĐĦ, LLC"
           :description "Unicode FTW"
-          :currency "FKP"
-          :logo ""})
+          :currency "FKP"}) ; Note: no logo on purpose
 
 ;; ----- Sections -----
 


### PR DESCRIPTION
Fix for: https://trello.com/c/K7JydNen

Base cause of this is RethinkDB skips documents w/o specified properties in retrieval, and logo was a specified property, but logo isn't added to the document until later by the bot (which might not finish).

To test:

- [x] Start on mainline
- [x] Update a sample data company such as Bago by erasing the `logo`, `logo-width` and `logo-height` properties
- [x] Reimport the company with the delete flag
- [x] Navigate to `/companies` in the web app and notice Bago is missing from the list
- [x] Switch to this branch, refresh `/companies`, notice Bago is back.

To review:

- [x] Review the code
- [x] Tests passing?

Deployment:

Current API branch for both staging and beta is called `email-snapshot`. So...

- [ ] Merge this into `mainline`
- [ ] Merge mainline into `email-snapshot`
- [ ] Deploy API `email-snapshot` w/ infrastructure `email-snapshot`