### PR TITLE
Prior Updates

### DIFF
--- a/opt/samples/18F.edn
+++ b/opt/samples/18F.edn
@@ -327,7 +327,7 @@
     {
       :section {
         :description "Growth metrics and key performance indicators"
-        :title "Growth"
+        :title "Key Metrics"
         :headline "Starting to See Billable Hours Growth"
         :body "<p>After a steady decline in the middle of the year, it's important to see that these numbers improving before the challenging ❄&nbsp;winter holiday season approaches . This has been a great job on all fronts 💥. Let's keep it up.</p>"
         :pin true

--- a/opt/samples/buff.edn
+++ b/opt/samples/buff.edn
@@ -2223,6 +2223,7 @@
       :title "Buffer in June 2015: Fastest-Ever Team Growth, $6.6M ARR"
       :sections ["growth" "finances" "help" "team" "product" "update"]
       :timestamp "2015-07-13T12:59:35.000Z"
+      :medium "link"
       :author {
         :name "Joel Gascoigne"
         :user-id "123456"
@@ -2235,6 +2236,7 @@
       :title "Buffer Investors’ Report: $6.86M ARR, Sixth Retreat, New ‘Areas’ Structure"
       :sections ["growth" "finances" "help" "team" "update" "product"]
       :timestamp "2015-08-13T16:26:47.000Z"
+      :medium "link"
       :author {
         :name "Joel Gascoigne"
         :user-id "123456"
@@ -2247,6 +2249,7 @@
       :title "Buffer in August: $7.49M ARR, Buffer for Video, Continued Growth"
       :sections ["growth" "finances" "team" "product" "customer-service" "help"]
       :timestamp "2015-09-18T18:33:45.000Z"
+      :medium "link"
       :author {
         :name "Joel Gascoigne"
         :user-id "123456"
@@ -2259,6 +2262,8 @@
       :title "50 Teammates, 17 Open Roles, New Calendar View & More: Buffer’s September Update"
       :sections ["update" "growth" "finances" "team" "product" "customer-service" "marketing"]
       :timestamp "2015-10-23T11:21:42.000Z"
+      :medium "link"
+      :note ""
       :author {
         :name "Joel Gascoigne"
         :user-id "123456"
@@ -2271,6 +2276,7 @@
       :title "Buffer in October: $7.8M Annual Revenue, Pablo 2.0 Launch, Customer Happiness at 95%"
       :sections ["growth" "finances" "team" "product" "customer-service" "marketing" "help"]
       :timestamp "2015-11-20T08:00:47.000Z"
+      :medium "link"
       :author {
         :name "Joel Gascoigne"
         :user-id "123456"

--- a/opt/samples/green-labs.edn
+++ b/opt/samples/green-labs.edn
@@ -44,7 +44,7 @@
     {
       :section {
         :description "Growth metrics and key performance indicators"
-        :title "Growth"
+        :title "Key Metrics"
         :image-url nil
         :image-width 0
         :image-height 0

--- a/opt/samples/simple.edn
+++ b/opt/samples/simple.edn
@@ -86,7 +86,7 @@
 
     {
       :section {
-        :title "Growth"
+        :title "Key Metrics"
         :headline ""
         :body "<p>This is excitingly simple growth!</p>"
         :metrics [

--- a/project.clj
+++ b/project.clj
@@ -13,7 +13,7 @@
 
   ;; All profile dependencies
   :dependencies [
-    [org.clojure/clojure "1.9.0-alpha13"] ; Lisp on the JVM http://clojure.org/documentation
+    [org.clojure/clojure "1.9.0-alpha14"] ; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/core.match "0.3.0-alpha4"] ; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.async "0.2.395"] ; Async programming and communication https://github.com/clojure/core.async
     [defun "0.3.0-RC1"] ; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
@@ -29,9 +29,9 @@
     [environ "1.1.0"] ; Environment settings from different sources https://github.com/weavejester/environ
     [cheshire "5.6.3"] ; JSON encoding / decoding https://github.com/dakrone/cheshire
     [com.taoensso/timbre "4.8.0-alpha1"] ; Logging https://github.com/ptaoussanis/timbre
-    [raven-clj "1.4.3"] ; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
+    [raven-clj "1.5.0"] ; Interface to Sentry error reporting https://github.com/sethtrain/raven-clj
     [clj-http "3.3.0"] ; HTTP client https://github.com/dakrone/clj-http
-    [clj-time "0.12.0"] ; Date and time lib https://github.com/clj-time/clj-time
+    [clj-time "0.12.2"] ; Date and time lib https://github.com/clj-time/clj-time
     [org.clojure/tools.cli "0.3.5"] ; Command-line parsing https://github.com/clojure/tools.cli
     [clj-jwt "0.1.1"] ; Library for JSON Web Token (JWT) https://github.com/liquidz/clj-jwt
     [medley "0.8.3"] ; Utility functions https://github.com/weavejester/medley

--- a/project.clj
+++ b/project.clj
@@ -16,7 +16,7 @@
     [org.clojure/clojure "1.9.0-alpha13"] ; Lisp on the JVM http://clojure.org/documentation
     [org.clojure/core.match "0.3.0-alpha4"] ; Erlang-esque pattern matching https://github.com/clojure/core.match
     [org.clojure/core.async "0.2.395"] ; Async programming and communication https://github.com/clojure/core.async
-    [defun "0.3.0-alapha"] ; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
+    [defun "0.3.0-RC1"] ; Erlang-esque pattern matching for Clojure functions https://github.com/killme2008/defun
     [lockedon/if-let "0.1.0"] ; More than one binding for if/when macros https://github.com/LockedOn/if-let
     [ring/ring-devel "1.6.0-beta6"] ; Web application library https://github.com/ring-clojure/ring
     [ring/ring-core "1.6.0-beta6"] ; Web application library https://github.com/ring-clojure/ring
@@ -36,8 +36,8 @@
     [clj-jwt "0.1.1"] ; Library for JSON Web Token (JWT) https://github.com/liquidz/clj-jwt
     [medley "0.8.3"] ; Utility functions https://github.com/weavejester/medley
     [com.stuartsierra/component "0.3.1"] ; Component Lifecycle
-    [amazonica "0.3.76"] ; A comprehensive Clojure client for the entire Amazon AWS api https://github.com/mcohen01/amazonica
-    [open-company/lib "0.0.4.2-6cdf3dd"] ; Library for OC projects https://github.com/open-company/open-company-lib
+    [amazonica "0.3.77"] ; A comprehensive Clojure client for the entire Amazon AWS api https://github.com/mcohen01/amazonica
+    [open-company/lib "0.0.5-5899489"] ; Library for OC projects https://github.com/open-company/open-company-lib
   ]
 
   ;; All profile plugins
@@ -57,7 +57,7 @@
         :open-company-auth-passphrase "this_is_a_qa_secret" ; JWT secret
       }
       :dependencies [
-        [midje "1.9.0-alpha5"] ; Example-based testing https://github.com/marick/Midje
+        [midje "1.9.0-alpha6"] ; Example-based testing https://github.com/marick/Midje
         [ring-mock "0.1.5"] ; Test Ring requests https://github.com/weavejester/ring-mock
         [philoskim/debux "0.2.1"] ; `dbg` macro around -> or let https://github.com/philoskim/debux
       ]

--- a/src/open_company/api/stakeholder_updates.clj
+++ b/src/open_company/api/stakeholder_updates.clj
@@ -44,7 +44,7 @@
   (if-let* [company (company-res/get-company conn company-slug)
             su-list (su-res/list-stakeholder-updates conn company-slug [:slug :title :medium :author])
             su-filtered-list (su-res/distinct-updates su-list)]
-    {:company company :stakeholder-updates su-list}
+    {:company company :stakeholder-updates su-filtered-list}
     false))
 
 (defn- stakeholder-update-for

--- a/src/open_company/api/stakeholder_updates.clj
+++ b/src/open_company/api/stakeholder_updates.clj
@@ -42,15 +42,32 @@
 
 (defn- list-stakeholder-updates [conn company-slug]
   (if-let* [company (company-res/get-company conn company-slug)
-            su-list (su-res/list-stakeholder-updates conn company-slug [:slug :title])]
+            su-list (su-res/list-stakeholder-updates conn company-slug [:slug :title :medium :author])
+            su-filtered-list (su-res/distinct-updates su-list)]
     {:company company :stakeholder-updates su-list}
     false))
+
+(defn- stakeholder-update-for
+  "Add the appropriate share details to the stakeholder-update for the share medium."
+  [company share]
+  (let [su (:stakeholder-update company)
+        note (or (:note share) "")
+        to (or (:to share) "")]
+    (cond
+      (:email share) (-> su
+                        (assoc :medium :email)
+                        (assoc :to to)
+                        (assoc :note note))
+      (:slack share) (-> su
+                        (assoc :medium :slack)
+                        (assoc :note note))
+      :else (assoc su :medium :link))))
 
 (defn- create-stakeholder-update [conn {:keys [company user] :as ctx}]
   (su-res/create-stakeholder-update! conn
     (su-res/->stakeholder-update conn
       company
-      (:stakeholder-update company)
+      (stakeholder-update-for company (:data ctx))
       user)))
 
 ;; ----- Resources - see: http://clojure-liberator.github.io/liberator/assets/img/decision-graph.svg
@@ -68,7 +85,7 @@
 
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
-    :get (fn [ctx] (common/allow-anonymous ctx))
+    :get (fn [ctx] (common/allow-anonymous ctx)) ; these are ObscURLs, so if you know what you're getting it's OK
     :delete (fn [ctx] (common/allow-org-members conn company-slug ctx))})
 
   ;; Delete a stakeholder update
@@ -98,7 +115,7 @@
   
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
-    :get (fn [ctx] (common/allow-anonymous ctx))
+    :get (fn [ctx] (common/allow-authenticated ctx)) ; protect the ObscURLs
     :post (fn [ctx] (common/allow-authenticated ctx))})
 
   ;; Create a new stakeholder update

--- a/src/open_company/api/stakeholder_updates.clj
+++ b/src/open_company/api/stakeholder_updates.clj
@@ -44,7 +44,7 @@
   (if-let* [company (company-res/get-company conn company-slug)
             su-list (su-res/list-stakeholder-updates conn company-slug [:slug :title :medium :author])
             su-filtered-list (su-res/distinct-updates su-list)]
-    {:company company :stakeholder-updates su-filtered-list}
+    {:company company :stakeholder-updates (reverse su-filtered-list)}
     false))
 
 (defn- stakeholder-update-for

--- a/src/open_company/api/stakeholder_updates.clj
+++ b/src/open_company/api/stakeholder_updates.clj
@@ -115,7 +115,8 @@
   
   :allowed? (by-method {
     :options (fn [ctx] (common/allow-anonymous ctx))
-    :get (fn [ctx] (common/allow-authenticated ctx)) ; protect the ObscURLs
+    :get (fn [ctx] (or (common/allow-public conn company-slug ctx) ; allow for all for public companies
+                       (common/allow-org-members conn company-slug ctx))) ; protect the ObscURLs of private ones
     :post (fn [ctx] (common/allow-authenticated ctx))})
 
   ;; Create a new stakeholder update

--- a/src/open_company/assets/migration.template.edn
+++ b/src/open_company/assets/migration.template.edn
@@ -1,6 +1,6 @@
 (ns open-company.db.migrations.MIGRATION-NAME
   (:require [rethinkdb.query :as r]
-            [oc.lib.rethinkdb.migration :as m]))
+            [oc.lib.rethinkdb.migrations :as m]))
 
 (defn up [conn]
   ;; Do great things

--- a/src/open_company/assets/sections.json
+++ b/src/open_company/assets/sections.json
@@ -84,12 +84,12 @@
 
     {
       "section-name": "growth",
-      "title": "Growth",
-      "description": "Growth metrics and key performance indicators",
+      "title": "Key Metrics",
+      "description": "Key metrics and performance indicators",
       "headline": "",
-      "body-placeholder": "Provide context about recent growth. Why are these metrics important? How are they performing against targets? What is impacting them?",
+      "body-placeholder": "Provide context about recent metric performance. Why are these metrics important? How are they performing against targets? What is impacting them?",
       "body": "",
-      "prompt": "Enter the most important growth metric for the stakeholders of your organization. You'll be able
+      "prompt": "Enter the most important metric for the stakeholders of your organization. You'll be able
       to add more later.",
       "metrics": [],
       "intervals": [

--- a/src/open_company/db/migrations/1477574597620_add_update_medium.edn
+++ b/src/open_company/db/migrations/1477574597620_add_update_medium.edn
@@ -1,0 +1,10 @@
+(ns open-company.db.migrations.add-update-medium
+  (:require [rethinkdb.query :as r]
+            [oc.lib.rethinkdb.migrations :as m]))
+
+(defn up [conn]
+  (-> (r/table "stakeholder_updates")
+    (r/update {:medium :legacy}) ; legacy means updates before we were tracking the medium
+    (r/run conn))
+
+  true) ; return true on success

--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -1,6 +1,6 @@
 (ns open-company.representations.company
   (:require [clojure.set :as cset]
-            [defun :refer (defun defun-)]
+            [defun.core :refer (defun defun-)]
             [cheshire.core :as json]
             [open-company.representations.common :as common]
             [open-company.representations.section :as section-rep]

--- a/src/open_company/representations/section.clj
+++ b/src/open_company/representations/section.clj
@@ -1,5 +1,5 @@
 (ns open-company.representations.section
-  (:require [defun :refer (defun-)]
+  (:require [defun.core :refer (defun-)]
             [cheshire.core :as json]
             [open-company.representations.common :as common]
             [open-company.resources.section :as section]))

--- a/src/open_company/representations/stakeholder_update.clj
+++ b/src/open_company/representations/stakeholder_update.clj
@@ -29,6 +29,8 @@
       :title (:title update)
       :slug slug
       :created-at (:created-at update)
+      :medium (:medium update)
+      :author (:author update)
       :links (if authorized [su-link (common/delete-link (stakeholder-update-url company-url slug))] [su-link])
     }))
 

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -108,6 +108,8 @@
           schema/Keyword schema/Any}
         InlineSections))
 
+(def ShareMedium (schema/pred #(#{:legacy :link :email :slack} (keyword %))))
+
 (def Stakeholder-update
   (merge {:company-slug Slug
           :slug schema/Str ; slug of the update, made from the slugified title and a short UUID
@@ -120,6 +122,9 @@
           :sections [SectionName]
           :created-at schema/Str
           :author Author ; user that created the update
+          :medium ShareMedium
+          (schema/optional-key :to) [schema/Str]
+          (schema/optional-key :note) schema/Str
           schema/Keyword schema/Any}
         InlineSections))
 

--- a/src/open_company/resources/section.clj
+++ b/src/open_company/resources/section.clj
@@ -1,7 +1,7 @@
 (ns open-company.resources.section
   (:require [clj-time.core :as t]
             [clj-time.format :as format]
-            [defun :refer (defun defun-)]
+            [defun.core :refer (defun defun-)]
             [open-company.config :as c]
             [open-company.resources.common :as common]
             [open-company.resources.company :as company]))

--- a/src/open_company/resources/stakeholder_update.clj
+++ b/src/open_company/resources/stakeholder_update.clj
@@ -152,8 +152,8 @@
          (every? :created-at updates)]}
   (let [all (reverse (sort-by :created-at updates)) ; all updates, most recent first
         by-author (vals (group-by #(-> % :author :user-id) all)) ; separate by distinct authorship
-        by-medium (apply concat (map #(vals (group-by :medium %)) by-author)) ; separate those by distinct medium
-        by-title (apply concat (map #(vals (group-by :title %)) by-medium)) ; separate those by distinct title
+        by-medium (mapcat #(vals (group-by :medium %)) by-author) ; separate those by distinct medium
+        by-title (mapcat #(vals (group-by :title %)) by-medium) ; separate those by distinct title
         time-filtered (map time-filter by-title)] ; filter those to the most recent per time period
     ; flatten the remaining sequences of distinct updates into a single sequence and order them by most recent
     (vec (reverse (sort-by :created-at (apply concat time-filtered))))))

--- a/src/open_company/resources/stakeholder_update.clj
+++ b/src/open_company/resources/stakeholder_update.clj
@@ -1,12 +1,16 @@
 (ns open-company.resources.stakeholder-update
   (:require [clojure.string :as s]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
             [schema.core :as schema]
             [if-let.core :refer (if-let*)]
-            [defun :refer (defun-)]
+            [defun.core :refer (defun-)]
             [oc.lib.slugify :as slug]
             [open-company.resources.common :as common]
             [open-company.resources.company :as company]
             [open-company.resources.section :as section]))
+
+(def update-hueristic-interval (t/hours 24)) ; updates longer apart than this can be considered distinct
 
 ;; ----- RethinkDB metadata -----
 
@@ -34,7 +38,32 @@
           section (section/get-section conn company-slug section-name as-of)
           clean-section (dissoc section :section-name :id :company-slug)]
       (recur (assoc su-props section-name clean-section) conn (rest sections)))))
+
+(defun- time-filter
+  "Recursive pattern matching function to only return the most recent updates in a time window.
+
+  Update argument already sorted by most recent."
   
+  ; initial start case
+  ([updates]
+  (let [this-update (first updates)
+        this-time (f/parse common/timestamp-format (:created-at this-update))]
+    (time-filter (rest updates) this-time [this-update]))) ; the most recent update is by definition distinct 
+
+  ; finish case, we checked them all, we're done
+  ([_updates :guard empty? _most-recent distinct-updates] distinct-updates)
+
+  ; progress case, check the next update and determine if it's in the interval (not distinct)
+  ; or outside the interval (distinct)
+  ([updates most-recent distinct-updates]
+  (let [this-update (first updates)
+        this-time (f/parse common/timestamp-format (:created-at this-update))]
+    (if (t/before? this-time (t/minus most-recent update-hueristic-interval))
+      ; it's distinct due to the time interval
+      (time-filter (rest updates) this-time (conj distinct-updates this-update))
+      ; it's within the interval, so skip it
+      (time-filter (rest updates) most-recent distinct-updates)))))
+
 ;; ----- Stakeholder update CRD (Create, Read, Delete) -----
 
 (schema/defn ->stakeholder-update :- common/Stakeholder-update
@@ -109,6 +138,25 @@
     (common/read-resources conn table-name "company-slug" company-slug)
     (sort-by :created-at)
     vec)))
+
+(defn distinct-updates
+  "Given a list of stakeholder updates, return a subset of them that are 'distinct' by the following hueristic:
+
+  The most recent update for a time period per author, share medium and title.
+  "
+  [updates]
+  {:pre [(sequential? updates)
+         (every? :author updates)
+         (every? :medium updates)
+         (every? :title updates)
+         (every? :created-at updates)]}
+  (let [all (reverse (sort-by :created-at updates)) ; all updates, most recent first
+        by-author (vals (group-by #(-> % :author :user-id) all)) ; separate by distinct authorship
+        by-medium (apply concat (map #(vals (group-by :medium %)) by-author)) ; separate those by distinct medium
+        by-title (apply concat (map #(vals (group-by :title %)) by-medium)) ; separate those by distinct title
+        time-filtered (map time-filter by-title)] ; filter those to the most recent per time period
+    ; flatten the remaining sequences of distinct updates into a single sequence and order them by most recent
+    (vec (reverse (sort-by :created-at (apply concat time-filtered))))))
 
 ;; ----- Armageddon -----
 

--- a/test/open_company/integration/stakeholder_update/stakeholder_update_create.clj
+++ b/test/open_company/integration/stakeholder_update/stakeholder_update_create.clj
@@ -131,13 +131,13 @@
           (fact "with 1 section"
             (mock/api-request :patch company-url {:body {:stakeholder-update {:title "1 section" :sections [:update]}}})
             (let [response (mock/api-request :post su-url {:body body})
-                  put-response-body (mock/body-from-response response)
-                  su-slug (:slug put-response-body)
+                  patch-response-body (mock/body-from-response response)
+                  su-slug (:slug patch-response-body)
                   db-response-body (su/get-stakeholder-update conn r/slug su-slug)]
               (:status response) => 201
               (get-in response [:headers "Location"]) => (su-rep/stakeholder-update-url company-url su-slug)
               ;; Check the response and the database
-              (doseq [response-body [put-response-body db-response-body]]
+              (doseq [response-body [patch-response-body db-response-body]]
                 (:title response-body) => "1 section"
                 (:sections response-body) => ["update"]
                 (-> response-body :author :name) => (:real-name r/coyote)
@@ -161,13 +161,13 @@
           (fact "with many sections"
             (mock/api-request :patch company-url {:body {:stakeholder-update {:title "Many sections" :sections [:update :finances :diversity]}}})
             (let [response (mock/api-request :post su-url {:body body})
-                  put-response-body (mock/body-from-response response)
-                  su-slug (:slug put-response-body)
+                  patch-response-body (mock/body-from-response response)
+                  su-slug (:slug patch-response-body)
                   db-response-body (su/get-stakeholder-update conn r/slug su-slug)]
               (:status response) => 201
               (get-in response [:headers "Location"]) => (su-rep/stakeholder-update-url company-url su-slug)
               ;; Check the response and the database
-              (doseq [response-body [put-response-body db-response-body]]
+              (doseq [response-body [patch-response-body db-response-body]]
                 (:title response-body) => "Many sections"
                 (:sections response-body) => ["update" "finances" "diversity"]
                 (-> response-body :author :name) => (:real-name r/coyote)
@@ -191,13 +191,13 @@
           (fact "with 1 custom section"
             (mock/api-request :patch company-url {:body {:stakeholder-update {:title "1 custom section" :sections [:custom-a1b2]}}})
             (let [response (mock/api-request :post su-url {:body body})
-                  put-response-body (mock/body-from-response response)
-                  su-slug (:slug put-response-body)
+                  patch-response-body (mock/body-from-response response)
+                  su-slug (:slug patch-response-body)
                   db-response-body (su/get-stakeholder-update conn r/slug su-slug)]
               (:status response) => 201
               (get-in response [:headers "Location"]) => (su-rep/stakeholder-update-url company-url su-slug)
               ;; Check the response and the database
-              (doseq [response-body [put-response-body db-response-body]]
+              (doseq [response-body [patch-response-body db-response-body]]
                 (:title response-body) => "1 custom section"
                 (:sections response-body) => ["custom-a1b2"]
                 (-> response-body :author :name) => (:real-name r/coyote)
@@ -221,13 +221,13 @@
           (fact "with mixed sections"
             (mock/api-request :patch company-url {:body {:stakeholder-update {:title "Mixed sections" :sections [:update :finances :diversity :custom-a1b2 :custom-r2d2]}}})
             (let [response (mock/api-request :post su-url {:body body})
-                  put-response-body (mock/body-from-response response)
-                  su-slug (:slug put-response-body)
+                  patch-response-body (mock/body-from-response response)
+                  su-slug (:slug patch-response-body)
                   db-response-body (su/get-stakeholder-update conn r/slug su-slug)]
               (:status response) => 201
               (get-in response [:headers "Location"]) => (su-rep/stakeholder-update-url company-url su-slug)
               ;; Check the response and the database
-              (doseq [response-body [put-response-body db-response-body]]
+              (doseq [response-body [patch-response-body db-response-body]]
                 (:title response-body) => "Mixed sections"
                 (:sections response-body) => ["update" "finances" "diversity" "custom-a1b2" "custom-r2d2"]
                 (-> response-body :author :name) => (:real-name r/coyote)

--- a/test/open_company/lib/check.clj
+++ b/test/open_company/lib/check.clj
@@ -3,7 +3,7 @@
   (:require [clojure.test :refer (is)]
             [clj-time.core :as t]
             [clj-time.format :as f]
-            [defun :refer (defun)]))
+            [defun.core :refer (defun)]))
 
 (defmacro check [forms]
   `(assert (is ~forms)))

--- a/test/open_company/lib/resources.clj
+++ b/test/open_company/lib/resources.clj
@@ -1,6 +1,8 @@
 (ns open-company.lib.resources
   "Namespace of data fixtures for use in tests."
-  (:require [clj-time.core :as t]))
+  (:require [clj-time.core :as t]
+            [clj-time.format :as format]
+            [open-company.resources.common :as common]))
 
 ;; ----- Names / constants -----
 
@@ -26,7 +28,7 @@
   :email "wile.e.coyote@acme.com"
   :owner false
   :admin false
-  :expire (t/plus (t/now) (t/days 1))
+  :expire (format/unparse common/timestamp-format (t/plus (t/now) (t/days 1)))
   :org-id "slack:98765"})
 
 (def camus {
@@ -37,7 +39,7 @@
   :email "albert@combat.org"
   :owner true
   :admin true
-  :expire (t/plus (t/now) (t/days 1))
+  :expire (format/unparse common/timestamp-format (t/plus (t/now) (t/days 1)))
   :org-id "slack:98765"
   :bot {:id "abc" :token "xyz"}})
 
@@ -49,7 +51,7 @@
   :email "sartre@lyceela.org"
   :owner true
   :admin true
-  :expire (t/plus (t/now) (t/days 1))
+  :expire (format/unparse common/timestamp-format (t/plus (t/now) (t/days 1)))
   :org-id "slack:87654"})
 
 ;; ----- Companies ----

--- a/test/open_company/lib/rest_api_mock.clj
+++ b/test/open_company/lib/rest_api_mock.clj
@@ -1,7 +1,7 @@
 (ns open-company.lib.rest-api-mock
   "Utility functions to help with REST API mock testing."
   (:require [clojure.string :as s]
-            [defun :refer (defun)]
+            [defun.core :refer (defun)]
             [ring.mock.request :refer (request body content-type header)]
             [cheshire.core :as json]
             [open-company.lib.test-setup :as ts]

--- a/test/open_company/unit/resources/stakeholder_update/distinct_updates.clj
+++ b/test/open_company/unit/resources/stakeholder_update/distinct_updates.clj
@@ -1,0 +1,126 @@
+(ns open-company.unit.resources.stakeholder-update.distinct-updates
+  (:require [midje.sweet :refer :all]
+            [clj-time.core :as t]
+            [clj-time.format :as f]
+            [open-company.lib.resources :as res]
+            [open-company.resources.common :as common]
+            [open-company.resources.stakeholder-update :as su]))
+
+;; ----- Utility Functions -----
+
+(defn- update-for [{:keys [title medium created-at author]}]
+  {:title (or title "")
+   :medium (or medium :link)
+   :created-at (if created-at (f/unparse common/timestamp-format created-at) (common/current-timestamp))
+   :author (or author res/coyote)})
+
+(defn- in-order [updates] (reverse (sort-by :created-at updates)))
+
+(defn- ago [interval] (t/minus (t/now) interval))
+
+;; ----- Tests -----
+
+(facts "about the distinct update hueristic"
+
+  (facts "and degenerate cases"
+    (su/distinct-updates nil) => (throws java.lang.AssertionError)
+    (su/distinct-updates []) => []
+    (let [one-update [(update-for {})]]
+      (su/distinct-updates one-update) => one-update))
+
+  (facts "about different causes of distinction"
+
+    (fact "different title"
+      (let [two-updates [(update-for {:title "One"}) (update-for {:title "Two" :created-at (ago (t/hours 1))})]]
+        ; 2 -> 2 distinct
+        (su/distinct-updates two-updates) => (in-order two-updates)))
+
+    (facts "different medium"
+      (let [two-updates [(update-for {}) (update-for {:medium :email :created-at (ago (t/hours 1))})]]
+        ; 2 -> 2 distinct
+        (su/distinct-updates two-updates) => (in-order two-updates))
+      (let [two-updates [(update-for {:medium :slack}) (update-for {:medium :email :created-at (ago (t/hours 1))})]]
+        ; 2 -> 2 distinct
+        (su/distinct-updates two-updates) => (in-order two-updates)))
+
+    (fact "different author"
+      (let [two-updates [(update-for {}) (update-for {:author res/camus :created-at (ago (t/hours 1))})]]
+        ; 2 -> 2 distinct
+        (su/distinct-updates two-updates) => (in-order two-updates)))
+
+    (fact "different day"
+      (let [two-updates [(update-for {}) (update-for {:created-at (ago (t/hours 25))})]]
+        ; 2 -> 2 distinct
+        (su/distinct-updates two-updates) => (in-order two-updates))))
+
+  (facts "and de-duplication"
+
+    (facts "because there is the same title, medium and author, and within a day"
+      (let [two-updates [(update-for {}) (update-for {:created-at (ago (t/hours 1))})]]
+        ; 2 -> 1 distinct
+        (su/distinct-updates two-updates) => [(first (in-order two-updates))])
+      (let [two-updates [(update-for {}) (update-for {:created-at (ago (t/hours 23))})]]
+        ; 2 -> 1 distinct
+        (su/distinct-updates two-updates) => [(first (in-order two-updates))]))
+
+    (facts "about complex scenarios"
+      (let [
+            ; 3 non-distinct links
+            link1 (update-for {})
+            link2 (update-for {:created-at (ago (t/hours 1))})
+            link3 (update-for {:created-at (ago (t/hours 2))})
+            ; 2 non-distinct links by a different author
+            link4 (update-for {:author res/camus :created-at (ago (t/hours 3))})
+            link5 (update-for {:author res/camus :created-at (ago (t/hours 4))})]
+        (su/distinct-updates [link1 link2 link3 link4 link5]) => (in-order [link1 link4]))
+
+      (let [
+            ; 4 non-distinct emails
+            email1 (update-for {:medium :email :created-at (ago (t/hours 5))})
+            email2 (update-for {:medium :email :created-at (ago (t/hours 6))})
+            email3 (update-for {:medium :email :created-at (ago (t/hours 7))})
+            email4 (update-for {:medium :email :created-at (ago (t/hours 8))})
+            ; 2 distinct emails by a different author
+            email5 (update-for {:medium :email :author res/camus :created-at (ago (t/hours 9))})
+            email6 (update-for {:medium :email :author res/camus :created-at (t/minus (t/now) (t/hours 34))})]
+        (su/distinct-updates [email1 email2 email3 email4 email5 email6]) => (in-order [email1 email5 email6]))
+
+      (let [
+            ; 2 non-distinct slacks
+            slack1 (update-for {:medium :slack :created-at (ago (t/hours 10))})
+            slack2 (update-for {:medium :slack :created-at (ago (t/hours 11))})
+            ; 3 slacks, different titles
+            slack3 (update-for {:medium :slack :title "1" :created-at (ago (t/hours 12))})
+            slack4 (update-for {:medium :slack :title "2" :created-at (ago (t/hours 13))})
+            slack5 (update-for {:medium :slack :title "3" :created-at (ago (t/hours 14))})]
+        (su/distinct-updates [slack1 slack2 slack3 slack4 slack5]) => (in-order [slack1 slack3 slack4 slack5]))
+
+      (let [
+            ; 3 non-distinct links
+            link1 (update-for {})
+            link2 (update-for {:created-at (ago (t/hours 1))})
+            link3 (update-for {:created-at (ago (t/hours 2))})
+            ; 2 non-distinct links by a different author
+            link4 (update-for {:author res/camus :created-at (ago (t/hours 3))})
+            link5 (update-for {:author res/camus :created-at (ago (t/hours 4))})
+            ; 4 non-distinct emails
+            email1 (update-for {:medium :email :created-at (ago (t/hours 5))})
+            email2 (update-for {:medium :email :created-at (ago (t/hours 6))})
+            email3 (update-for {:medium :email :created-at (ago (t/hours 7))})
+            email4 (update-for {:medium :email :created-at (ago (t/hours 8))})
+            ; 2 distinct emails by a different author
+            email5 (update-for {:medium :email :author res/camus :created-at (ago (t/hours 9))})
+            email6 (update-for {:medium :email :author res/camus :created-at (t/minus (t/now) (t/hours 34))})
+            ; 2 non-distinct slacks
+            slack1 (update-for {:medium :slack :created-at (ago (t/hours 10))})
+            slack2 (update-for {:medium :slack :created-at (ago (t/hours 11))})
+            ; 3 slacks, different titles
+            slack3 (update-for {:medium :slack :title "1" :created-at (ago (t/hours 12))})
+            slack4 (update-for {:medium :slack :title "2" :created-at (ago (t/hours 13))})
+            slack5 (update-for {:medium :slack :title "3" :created-at (ago (t/hours 14))})]
+        (su/distinct-updates [link1 link2 link3 link4 link5
+                              email1 email2 email3 email4 email5 email6
+                              slack1 slack2 slack3 slack4 slack5]) => (in-order [link1 link4
+                                                                                 email1 email5
+                                                                                 slack1 slack3 slack4 slack5
+                                                                                 email6])))))


### PR DESCRIPTION
This API change supports showing prior updates in the UI.

The main change of this PR is to implement a heuristic by which we don't return every 
This PR also has us keeping the share details that get passed on to the email/bot services with the update so we have data on how the update was shared.

It also updates the default "growth" title to be "Key Metrics".

To test:

* Review the code
* Review the new tests in `distinct_updates.clj`. Do they test the new heuristic?
* Look at prior updates in the web UI, does it work? Does it implement the heuristic in your testing?
* Merge
* Review the UI PR
* Deploy them to beta
* Dance, dance, dance

