### PR TITLE
Update code and tests for collapsing distinct mediums

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,12 +477,12 @@ http://localhost:3000/companies/hotel-procrastination
 
 To import company sample data from an edn file run:
 ```console
-lein run -m open-company.util.sample-data -- ./opt/samples/buffer.edn
+lein run -m open-company.util.sample-data -- ./opt/samples/buff.edn
 ```
 
 use `-d` to erase the company while importing like this:
 ```console
-lein run -m open-company.util.sample-data -- -d ./opt/samples/buffer.edn
+lein run -m open-company.util.sample-data -- -d ./opt/samples/buff.edn
 ```
 
 To add all the company sample data in a directory (each file with a `.edn` extension), run:
@@ -498,7 +498,7 @@ lein run -m open-company.util.sample-data -- -d ./opt/samples/
 To add sample data on a production environment, specify the production database name:
 
 ```console
-DB_NAME="open_company" lein run -m open-company.util.sample-data -- -d ./opt/samples/buffer.edn
+DB_NAME="open_company" lein run -m open-company.util.sample-data -- -d ./opt/samples/buff.edn
 ```
 
 or

--- a/project.clj
+++ b/project.clj
@@ -64,7 +64,7 @@
       :plugins [
         [lein-midje "3.2.1"] ; Example-based testing https://github.com/marick/lein-midje
         [jonase/eastwood "0.2.3"] ; Linter https://github.com/jonase/eastwood
-        [lein-kibit "0.1.2"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
+        [lein-kibit "0.1.3"] ; Static code search for non-idiomatic code https://github.com/jonase/kibit
       ]
     }
 
@@ -88,6 +88,7 @@
         [lein-spell "0.1.0"] ; Catch spelling mistakes in docs and docstrings https://github.com/cldwalker/lein-spell
         [lein-deps-tree "0.1.2"] ; Print a tree of project dependencies https://github.com/the-kenny/lein-deps-tree
         [venantius/yagni "0.1.4"] ; Dead code finder https://github.com/venantius/yagni
+        [lein-zprint "0.1.9"] ; Pretty-print clj and EDN https://github.com/kkinnear/lein-zprint
       ]  
     }]
     :repl-config [:dev {
@@ -168,6 +169,8 @@
     :exclude-namespaces [:test-paths]
   }
 
+  :zprint {:old? false}
+  
   ;; ----- API -----
 
   :ring {

--- a/test/open_company/unit/resources/stakeholder_update/distinct_updates.clj
+++ b/test/open_company/unit/resources/stakeholder_update/distinct_updates.clj
@@ -47,7 +47,7 @@
 
   (facts "and de-duplication"
 
-    (facts "because there is the same title, author, and within a day"
+    (facts "because there is the same title and author within a day"
       (let [two-updates [(update-for {}) (update-for {:created-at (ago (t/hours 1))})]]
         ; 2 -> 1 distinct
         (su/distinct-updates two-updates) => [(first (in-order two-updates))])


### PR DESCRIPTION
https://trello.com/c/JctchmaC

Requires this UI PR: https://github.com/open-company/open-company-web/pull/209

This PR removes share medium as a cause of distinction in prior updates, and instead has collapsed updates accumulate all the ways they've been shared, so that medium in the returned update may be sequential.

To test:

* Review the code of both PRs
* Review the updated tests of this PR. Do they pass? Do they cover collapsing medium scenarios?
* Test in the UI by looking at the update list of some existing companies you have, Buffer, etc. Nothing broken?
* Create a new update with a new title
* Share it as a link, check the update list, has link as medium?
* Share it (don't change the title) by email, check the update list, has link and email?
* Share it (don't change the title) by Slack, check the update list, has link and email and Slack?
* Merge
* Deploy
* Drop and give me 20