### PR TITLE
…

### DIFF
--- a/src/open_company/representations/company.clj
+++ b/src/open_company/representations/company.clj
@@ -76,8 +76,8 @@
 
 (defn- stakeholder-updates-link
   "Add HATEOAS links to existing stakeholder updates"
-  [company]
-  (update-in company [:links] conj (su-rep/stakeholder-updates-link (url company))))
+  [company conn]
+  (update-in company [:links] conj (su-rep/stakeholder-updates-link conn (:slug company) (url company))))
 
 (defn- stakeholder-update-create-link
   "Add the HATEOAS link to create a new stakeholder update if authorized"
@@ -88,10 +88,10 @@
 
 (defn- stakeholder-update-links
   "Add the stakeholder update HATEOAS links to the company"
-  [company authorized]
+  [company conn authorized]
   (-> company
     (stakeholder-update-create-link authorized)
-    (stakeholder-updates-link)))
+    (stakeholder-updates-link conn)))
 
 (defn- company-for-rendering
   "Get a representation of the company for the REST API"
@@ -102,7 +102,7 @@
     (assoc :revisions (company/list-revisions conn slug))
     (update :revisions #(map (fn [rev] (revision-link slug (:updated-at rev))) %))
     (company-links (if authorized :all-links [:self]))
-    (stakeholder-update-links authorized)
+    (stakeholder-update-links conn authorized)
     (sections* conn authorized)
     (assoc :archived (company/archived-sections conn slug)))))
 

--- a/src/open_company/representations/stakeholder_update.clj
+++ b/src/open_company/representations/stakeholder_update.clj
@@ -1,5 +1,6 @@
 (ns open-company.representations.stakeholder-update
   (:require [cheshire.core :as json]
+            [open-company.resources.stakeholder-update :as su]
             [open-company.representations.common :as common]))
 
 (def ^:private clean-properties [:id :updated-at :company-slug])
@@ -19,8 +20,12 @@
 (defn create-link [company-url]
   (common/link-map "share" common/POST (stakeholder-updates-url company-url) nil))
 
-(defn stakeholder-updates-link [company-url]
-  (common/link-map "stakeholder-updates" common/GET (stakeholder-updates-url company-url) collection-media-type))
+(defn stakeholder-updates-link [conn company-slug company-url]
+  "Create a HATEOAS link to be used to retrieve stakeholder updates and annotate it
+  with a count of how many updates exist."
+  (assoc
+    (common/link-map "stakeholder-updates" common/GET (stakeholder-updates-url company-url) collection-media-type)
+    :count (su/count-stakeholder-updates conn company-slug)))
 
 (defn- stakeholder-update-fragment [company-url update authorized]
   (let [slug (:slug update)

--- a/src/open_company/representations/stakeholder_update.clj
+++ b/src/open_company/representations/stakeholder_update.clj
@@ -20,9 +20,10 @@
 (defn create-link [company-url]
   (common/link-map "share" common/POST (stakeholder-updates-url company-url) nil))
 
-(defn stakeholder-updates-link [conn company-slug company-url]
+(defn stakeholder-updates-link
   "Create a HATEOAS link to be used to retrieve stakeholder updates and annotate it
   with a count of how many updates exist."
+  [conn company-slug company-url]
   (assoc
     (common/link-map "stakeholder-updates" common/GET (stakeholder-updates-url company-url) collection-media-type)
     :count (su/count-stakeholder-updates conn company-slug)))

--- a/src/open_company/resources/common.clj
+++ b/src/open_company/resources/common.clj
@@ -231,6 +231,16 @@
       (r/get primary-key-value)
       (r/run conn)))
 
+(defn count-resources
+  "Given a table name, and an index name and value, return a count of the number of matching
+  documents in the database."
+  [conn table-name index-name index-value]
+  (with-timeout default-timeout
+   (-> (r/table table-name)
+       (r/get-all [index-value] {:index index-name})
+       (r/count)
+       (r/run conn))))
+
 (defn read-resources
   "Given a table name, and an optional index name and value, and an optional set of fields, retrieve
   the resources from the database."

--- a/src/open_company/resources/stakeholder_update.clj
+++ b/src/open_company/resources/stakeholder_update.clj
@@ -137,6 +137,13 @@
 
 ;; ----- Collection of stakeholder updates -----
 
+(defn count-stakeholder-updates
+  ""
+  [conn company-slug]
+  {:pre [(map? conn) (string? company-slug)]
+   :post [(number? %)]}
+  (common/count-resources conn table-name "company-slug" company-slug))
+
 (defn list-stakeholder-updates
   "
   Return a sequence of maps for each stakeholder update for the specified company


### PR DESCRIPTION
https://trello.com/c/3BhPUZqU

Added a resource count to common, used by stakeholder update resource, used by stakeholder update representation to add a count property to the stakeholder update link for companies.

To test: Retrieve a company w/ no updates and some updates (logged out public, logged in private) and observe the new "count" property. Is it accurate to the # of updates that exist? (NB: this is not the same number as the # of distinct updates that exist, that's a more complicated and costly calculation, so this is the "raw" # of updates that exist).