### PR TITLE
Include interaction websocket link in board responses.

### DIFF
--- a/src/oc/storage/api/access.clj
+++ b/src/oc/storage/api/access.clj
@@ -36,6 +36,7 @@
   Or, given an org (or slug), board (or slug) and user map, return the authorization level for the user on the board:
     :author
     :viewer
+    :public
     false
   "
   
@@ -73,7 +74,7 @@
       
       ;; public access to orgs w/ at least 1 public board
       (seq (board-res/list-boards-by-index conn "org-uuid-access" [[org-uuid "public"]]))
-        {:access-level :viewer}
+        {:access-level :public}
       
       ;; no access
       :else false)))
@@ -127,7 +128,7 @@
       (and (not= board-access :private) ((set teams) (:team-id org))) {:access-level :viewer}
       
       ;; anyone else on a public board
-      (= board-access :public) {:access-level :viewer}
+      (= board-access :public) {:access-level :public}
       
       ;; no access
       :else false))))

--- a/src/oc/storage/config.clj
+++ b/src/oc/storage/config.clj
@@ -44,6 +44,7 @@
 ;; ----- URLs -----
 
 (defonce interaction-server-url (or (env :interaction-server-url) "http://localhost:3002"))
+(defonce interaction-server-ws-url (or (env :interaction-server-ws-url) "ws://localhost:3002"))
 
 ;; ----- Liberator -----
 


### PR DESCRIPTION
Supports PR: https://github.com/open-company/open-company-interaction/pull/2

To test, look at board JSON responses. Do they contain a unique websocket URL for each board if the user is an author or a viewer? Is it the correct URL? 

Is the URL not there for public and/or anonymous access?

Groovy. Merge this bad boy.